### PR TITLE
Clearer Python version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "scportrait"
 version = "1.0.0"
 description = "Computational framework to generate single cell datasets from raw microscopy images."
 readme = "README.md"
-requires-python = ">=3.10, !=3.12.*"
+requires-python = ">=3.10, <3.12"
 license = {file = "LICENSE"}
 keywords = ["single-cell", "image analysis", "spatial omics", "deep learning", "image representation"]
 dynamic = ["dependencies", "optional-dependencies"]


### PR DESCRIPTION
I assume that you wouldn't support Python 3.13 either which will be out very soon: 3.13.0 final: Tuesday, 2024-10-01