### PR TITLE
fix bug in project

### DIFF
--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -1097,7 +1097,7 @@ class Project(Logable):
     def select(
         self,
         cell_sets: list[dict],
-        calibration_marker: np.array | None = None,
+        calibration_marker: np.ndarray | None = None,
         segmentation_name: str = "seg_all_nucleus",
         name: str | None = None,
     ):


### PR DESCRIPTION
np.array is not a type


TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'