### PR TITLE
Fix bugs in datasets.py

### DIFF
--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -53,6 +53,7 @@ class _HDF5SingleCellDataset(Dataset):
         self.transform = transform
         self.return_id = return_id
         self.return_fake_id = return_fake_id
+        self.max_level = max_level
 
         assert (
             not self.return_id and self.return_fake_id
@@ -272,7 +273,7 @@ class _HDF5SingleCellDataset(Dataset):
             current_index_list = self.index_list[i]
 
             # get current label
-            self._get_dataset_label(i)
+            # self._get_dataset_label(i) has not been implemented yet
 
             # check if "directory" is a path to specific hdf5
             filetype = directory.split(".")[-1]
@@ -442,7 +443,7 @@ class HDF5SingleCellDataset(_HDF5SingleCellDataset):
         self.bulk_labels = dir_labels
         self.read_labels_from_dataset = False
 
-        self._add_all_dataset(read_label_from_dataset=self.read_labels_from_dataset)
+        self._add_all_datasets(read_label_from_dataset=self.read_labels_from_dataset)
         self.stats()
 
 


### PR DESCRIPTION
I ran into a couple of problems while calling HDF5SingleCellDataset().

`_add_all_dataset()` should be `_add_all_datasets()`

`_get_dataset_label(i)` does not exist yet, so I commented it out

`self.max_levels` could not be found in the parent class, so I defined it 

I ran it after fixing those points and it seemed to work fine.