### PR TITLE
truncate image paths in BIAS generated XML

### DIFF
--- a/src/scportrait/tools/stitch/_utils/filewriters.py
+++ b/src/scportrait/tools/stitch/_utils/filewriters.py
@@ -164,6 +164,8 @@ def write_xml(image_paths: list[str], channels: list[str], slidename: str, outdi
                         text(channel)
         with tag("images"):
             for i, image_path in enumerate(image_paths):
+                # truncate image_path to only include the filename
+                image_path = os.path.basename(image_path)
                 with tag("image", url=str(image_path)):
                     with tag("channel"):
                         text(str(i + 1))


### PR DESCRIPTION
this fixes needing to manually update the complete file paths if images are relocated. As the XML should always be in the same folder as the generated TIF files there is no need for absolute file path names.