### PR TITLE
Fix sdata annotations

### DIFF
--- a/src/scportrait/pipeline/classification.py
+++ b/src/scportrait/pipeline/classification.py
@@ -552,7 +552,9 @@ class _ClassificationBase(ProcessingStep):
             # save nucleus segmentation
             obs = pd.DataFrame()
             obs.index = obs_indices
-            obs["instance_id"] = obs_indices
+            obs["instance_id"] = obs_indices.astype(
+                int
+            )  # this needs to be int otherwise data will not be loaded correctly
             obs["region"] = f"{mask_type}_{self.MASK_NAMES[0]}"
             obs["region"] = obs["region"].astype("category")
 
@@ -574,7 +576,9 @@ class _ClassificationBase(ProcessingStep):
             # save cytoplasm segmentation
             obs = pd.DataFrame()
             obs.index = obs_indices
-            obs["instance_id"] = obs_indices
+            obs["instance_id"] = obs_indices.astype(
+                int
+            )  # this needs to be int otherwise data will not be loaded correctly
             obs["region"] = f"{mask_type}_{self.MASK_NAMES[1]}"
             obs["region"] = obs["region"].astype("category")
 
@@ -1200,7 +1204,7 @@ class _cellFeaturizerBase(_ClassificationBase):
 
             obs = pd.DataFrame()
             obs.index = obs_indices
-            obs["instance_id"] = obs_indices
+            obs["instance_id"] = obs_indices.astype(int)
             obs["region"] = f"{mask_type}_{self.MASK_NAMES[0]}"
             obs["region"] = obs["region"].astype("category")
 
@@ -1236,7 +1240,7 @@ class _cellFeaturizerBase(_ClassificationBase):
 
             obs = pd.DataFrame()
             obs.index = obs_indices
-            obs["instance_id"] = obs_indices
+            obs["instance_id"] = obs_indices.astype(int)
             obs["region"] = f"{mask_type}_{self.MASK_NAMES[1]}"
             obs["region"] = obs["region"].astype("category")
 

--- a/src/scportrait/pipeline/classification.py
+++ b/src/scportrait/pipeline/classification.py
@@ -566,7 +566,7 @@ class _ClassificationBase(ProcessingStep):
                 instance_key="instance_id",
             )
 
-            self.project._write_table_object_sdata(
+            self.filehandler._write_table_object_sdata(
                 table,
                 f"{self.__class__.__name__ }_{label}_{self.MASK_NAMES[0]}",
                 overwrite=self.overwrite_run_path,
@@ -590,7 +590,7 @@ class _ClassificationBase(ProcessingStep):
                 instance_key="instance_id",
             )
 
-            self.project._write_table_object_sdata(
+            self.filehandler._write_table_object_sdata(
                 table,
                 f"{self.__class__.__name__ }_{label}_{self.MASK_NAMES[1]}",
                 overwrite=self.overwrite_run_path,

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -933,7 +933,7 @@ class Project(Logable):
 
                         table = remap_region_annotation_table(table, region_name=region_name)
 
-                        self._write_table_object_sdata(table, new_table_name)
+                        self.filehandler._write_table_object_sdata(table, new_table_name)
                         self.log(
                             f"Added annotation {new_table_name} to spatialdata object for segmentation object {region_name}."
                         )
@@ -955,7 +955,7 @@ class Project(Logable):
                         new_table_name = f"annot_{region_name}_{table_name}"
 
                         table = remap_region_annotation_table(table, region_name=region_name)
-                        self._write_table_object_sdata(table, new_table_name)
+                        self.filehandler._write_table_object_sdata(table, new_table_name)
 
                         self.log(
                             f"Added annotation {new_table_name} to spatialdata object for segmentation object {region_name}."


### PR DESCRIPTION
ensure that classification results are correctly mapped to their corresponding segmentation objects so that these can be visualised in Napari