### PR TITLE
Included static redirect from old URL

### DIFF
--- a/docs/html/index.rst
+++ b/docs/html/index.rst
@@ -1,0 +1,3 @@
+.. raw:: html
+
+    <meta http-equiv="refresh" content="0; url=https://mannlabs.github.io/scPortrait/index.html">


### PR DESCRIPTION
Old URL (.../html/index.html) now links to https://mannlabs.github.io/scPortrait/index.html. This is hardcoded, will need to be adapted in case docs move.