### PR TITLE
implement consistent timing benchmarks across all segmentation workflows

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ author = "Sophia Mädler and Niklas Schmacke"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.doctest",
     "sphinxarg.ext",
     "sphinx_rtd_theme",
     "nbsphinx",

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -122,7 +122,6 @@ class Segmentation(ProcessingStep):
         self.n_processes = 1
 
     def _check_gpu_status(self):
-        # check if cuda GPU is available
         if torch.cuda.is_available():
             self.use_GPU = True
             self.device = "cuda"

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -119,7 +119,7 @@ class Segmentation(ProcessingStep):
         self.cyto_seg_name = cyto_seg_name
         self._tmp_image_path = _tmp_image_path
         self.processes_per_GPU = None
-        self.n_processes = 1 #default value that shoudl work for all processes
+        self.n_processes = 1  # default value that shoudl work for all processes
 
     def _check_gpu_status(self):
         # check if cuda GPU is available

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -118,6 +118,8 @@ class Segmentation(ProcessingStep):
         self.nuc_seg_name = nuc_seg_name
         self.cyto_seg_name = cyto_seg_name
         self._tmp_image_path = _tmp_image_path
+        self.processes_per_GPU = None
+        self.n_processes = 1 #default value that shoudl work for all processes
 
     def _check_gpu_status(self):
         # check if cuda GPU is available

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -119,7 +119,7 @@ class Segmentation(ProcessingStep):
         self.cyto_seg_name = cyto_seg_name
         self._tmp_image_path = _tmp_image_path
         self.processes_per_GPU = None
-        self.n_processes = 1  # default value that shoudl work for all processes
+        self.n_processes = 1
 
     def _check_gpu_status(self):
         # check if cuda GPU is available

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1012,6 +1012,7 @@ class WGASegmentation(_ClassicalSegmentation):
         return segmentation
 
     def _execute_segmentation(self, input_image):
+        total_time_start = timeit.default_timer()
         self._get_processing_parameters()
 
         # intialize maps for storing intermediate results
@@ -1063,7 +1064,7 @@ class WGASegmentation(_ClassicalSegmentation):
         print("Channels shape: ", segmentation.shape)
 
         results = self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
-        return results
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class ShardedWGASegmentation(ShardedSegmentation):
@@ -1086,6 +1087,7 @@ class DAPISegmentation(_ClassicalSegmentation):
         return segmentation
 
     def _execute_segmentation(self, input_image):
+        total_time_start = timeit.default_timer()
         self._get_processing_parameters()
 
         # intialize maps for storing intermediate results
@@ -1124,7 +1126,7 @@ class DAPISegmentation(_ClassicalSegmentation):
         segmentation = self._finalize_segmentation_results()
 
         results = self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
-        return results
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class ShardedDAPISegmentation(ShardedSegmentation):
@@ -1311,6 +1313,8 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
         self._clear_cache(vars_to_delete=[model, diameter, masks])
 
     def _execute_segmentation(self, input_image):
+        total_time_start = timeit.default_timer()
+
         # check that the correct level of input image is used
         input_image = self._transform_input_image(input_image)
 
@@ -1339,6 +1343,7 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
 
         segmentation = self._finalize_segmentation_results()
         self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class ShardedDAPISegmentationCellpose(ShardedSegmentation):
@@ -1466,6 +1471,8 @@ class CytosolSegmentationCellpose(_CellposeSegmentation):
         self._clear_cache(vars_to_delete=[masks_nucleus, masks_cytosol])
 
     def _execute_segmentation(self, input_image):
+        total_time_start = timeit.default_timer()
+
         # ensure the correct level is selected for the input image
         input_image = self._transform_input_image(input_image)
 
@@ -1502,6 +1509,7 @@ class CytosolSegmentationCellpose(_CellposeSegmentation):
 
         # clean up memory
         self._clear_cache(vars_to_delete=[segmentation, all_classes])
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class ShardedCytosolSegmentationCellpose(ShardedSegmentation):
@@ -1535,6 +1543,8 @@ class CytosolSegmentationDownsamplingCellpose(CytosolSegmentationCellpose):
         return segmentation
 
     def _execute_segmentation(self, input_image):
+        total_time_start = timeit.default_timer()
+
         # ensure the correct level is selected for the input image
         input_image = self._transform_input_image(input_image)
 
@@ -1584,6 +1594,7 @@ class CytosolSegmentationDownsamplingCellpose(CytosolSegmentationCellpose):
 
         self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
         self._clear_cache(vars_to_delete=[segmentation, all_classes])
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class ShardedCytosolSegmentationDownsamplingCellpose(ShardedSegmentation):
@@ -1754,6 +1765,8 @@ class CytosolOnly_Segmentation_Downsampling_Cellpose(CytosolOnlySegmentationCell
         return segmentation
 
     def _execute_segmentation(self, input_image) -> None:
+        total_time_start = timeit.default_timer()
+
         # ensure the correct level is selected for the input image
         input_image = self._transform_input_image(input_image)
 
@@ -1795,8 +1808,7 @@ class CytosolOnly_Segmentation_Downsampling_Cellpose(CytosolOnlySegmentationCell
         segmentation = self._finalize_segmentation_results()  # type: ignore
 
         self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
-
-        return None
+        self.total_time = timeit.default_timer() - total_time_start
 
 
 class Sharded_CytosolOnly_Segmentation_Downsampling_Cellpose(ShardedSegmentation):

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1063,7 +1063,7 @@ class WGASegmentation(_ClassicalSegmentation):
 
         print("Channels shape: ", segmentation.shape)
 
-        results = self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
+        self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
         self.total_time = timeit.default_timer() - total_time_start
 
 
@@ -1125,7 +1125,7 @@ class DAPISegmentation(_ClassicalSegmentation):
         all_classes = list(set(np.unique(self.maps["nucleus_segmentation"])) - {0})
         segmentation = self._finalize_segmentation_results()
 
-        results = self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
+        self._save_segmentation_sdata(segmentation, all_classes, masks=self.MASK_NAMES)
         self.total_time = timeit.default_timer() - total_time_start
 
 

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1306,7 +1306,7 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
 
     def _execute_segmentation(self, input_image):
         # check that the correct level of input image is used
-        self._transform_input_image(input_image)
+        input_image = self._transform_input_image(input_image)
 
         # check that the image is of the correct dtype
         self._check_input_image_dtype(input_image)
@@ -1526,7 +1526,7 @@ class CytosolSegmentationDownsamplingCellpose(CytosolSegmentationCellpose):
 
     def _execute_segmentation(self, input_image):
         # ensure the correct level is selected for the input image
-        self._transform_input_image(input_image)
+        input_image = self._transform_input_image(input_image)
 
         # check image dtype since cellpose expects int input images
         self._check_input_image_dtype(input_image)
@@ -1649,7 +1649,7 @@ class CytosolOnlySegmentationCellpose(_CellposeSegmentation):
         total_time_start = timeit.default_timer()
 
         # transform input image
-        self._transform_input_image(input_image)
+        input_image = self._transform_input_image(input_image)
 
         # check image dtype since cellpose expects int input images
         self._check_input_image_dtype(input_image)
@@ -1743,7 +1743,7 @@ class CytosolOnly_Segmentation_Downsampling_Cellpose(CytosolOnlySegmentationCell
 
     def _execute_segmentation(self, input_image) -> None:
         # ensure the correct level is selected for the input image
-        self._transform_input_image(input_image)
+        input_image = self._transform_input_image(input_image)
 
         # check image dtype since cellpose expects int input images
         self._check_input_image_dtype(input_image)

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -38,8 +38,11 @@ class _BaseSegmentation(Segmentation):
         super().__init__(*args, **kwargs)
 
     def _transform_input_image(self, input_image):
+        start_transform = timeit.default_timer()
         if isinstance(input_image, xarray.DataArray):
             input_image = input_image.data
+        stop_transform = timeit.default_timer()
+        self.transform_time = stop_transform - start_transform
         return input_image
 
     def return_empty_mask(self, input_image):
@@ -1646,10 +1649,7 @@ class CytosolOnlySegmentationCellpose(_CellposeSegmentation):
         total_time_start = timeit.default_timer()
 
         # transform input image
-        start_transform = timeit.default_timer()
         self._transform_input_image(input_image)
-        stop_transform = timeit.default_timer()
-        self.transform_time = stop_transform - start_transform
 
         # check image dtype since cellpose expects int input images
         self._check_input_image_dtype(input_image)

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1318,7 +1318,6 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
         # check that the correct level of input image is used
         input_image = self._transform_input_image(input_image)
 
-        # check that the image is of the correct dtype
         self._check_input_image_dtype(input_image)
 
         # only get the first cannel for segmentation (does not use excess space on the GPU this way)

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1041,6 +1041,7 @@ class WGASegmentation(_ClassicalSegmentation):
             # update input image to median corrected image
             input_image = self.maps["median_corrected"]
 
+        start_segmentation = timeit.default_timer()
         if self.segment_nuclei:
             image = input_image[0]
             self._nucleus_segmentation(image, debug=self.debug)
@@ -1050,6 +1051,8 @@ class WGASegmentation(_ClassicalSegmentation):
             if isinstance(image, xarray.DataArray):
                 image = image.data.compute()
             self._cytosol_segmentation(image, debug=self.debug)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         if self.debug:
             self._visualize_final_masks()
@@ -1111,8 +1114,11 @@ class DAPISegmentation(_ClassicalSegmentation):
             # update input image to median corrected image
             input_image = self.maps["median_corrected"]
 
+        start_segmentation = timeit.default_timer()
         if self.segment_nuclei:
             self._nucleus_segmentation(input_image[0], debug=self.debug)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         all_classes = list(set(np.unique(self.maps["nucleus_segmentation"])) - {0})
         segmentation = self._finalize_segmentation_results()
@@ -1323,8 +1329,10 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
             ),
         }
 
-        self.log("Starting Cellpose DAPI Segmentation.")
+        start_segmentation = timeit.default_timer()
         self.cellpose_segmentation(input_image)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         # finalize classes list
         all_classes = set(np.unique(self.maps["nucleus_segmentation"])) - {0}
@@ -1481,8 +1489,10 @@ class CytosolSegmentationCellpose(_CellposeSegmentation):
             ),
         }
 
-        # self.log("Starting Cellpose DAPI Segmentation.")
+        start_segmentation = timeit.default_timer()
         self.cellpose_segmentation(input_image)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         # finalize segmentation classes ensuring that background is removed
         all_classes = set(np.unique(self.maps["nucleus_segmentation"])) - {0}
@@ -1562,8 +1572,10 @@ class CytosolSegmentationDownsamplingCellpose(CytosolSegmentationCellpose):
             ),
         }
 
-        # self.log("Starting Cellpose DAPI Segmentation.")
+        start_segmentation = timeit.default_timer()
         self.cellpose_segmentation(input_image)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         # finalize classes list
         all_classes = set(np.unique(self.maps["nucleus_segmentation"])) - {0}
@@ -1772,7 +1784,10 @@ class CytosolOnly_Segmentation_Downsampling_Cellpose(CytosolOnlySegmentationCell
             ),
         }
 
+        start_segmentation = timeit.default_timer()
         self.cellpose_segmentation(input_image)
+        stop_segmentation = timeit.default_timer()
+        self.segmentation_time = stop_segmentation - start_segmentation
 
         # currently no implemented filtering steps to remove nuclei outside of specific thresholds
         all_classes = set(np.unique(self.maps["cytosol_segmentation"])) - {0}

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -1008,7 +1008,7 @@ class WGASegmentation(_ClassicalSegmentation):
 
         return segmentation
 
-    def process(self, input_image):
+    def _execute_segmentation(self, input_image):
         self._get_processing_parameters()
 
         # intialize maps for storing intermediate results
@@ -1079,7 +1079,7 @@ class DAPISegmentation(_ClassicalSegmentation):
 
         return segmentation
 
-    def process(self, input_image):
+    def _execute_segmentation(self, input_image):
         self._get_processing_parameters()
 
         # intialize maps for storing intermediate results
@@ -1301,7 +1301,7 @@ class DAPISegmentationCellpose(_CellposeSegmentation):
         # manually delete model and perform gc to free up memory on GPU
         self._clear_cache(vars_to_delete=[model, diameter, masks])
 
-    def process(self, input_image):
+    def _execute_segmentation(self, input_image):
         # check that the correct level of input image is used
         self._transform_input_image(input_image)
 
@@ -1454,7 +1454,7 @@ class CytosolSegmentationCellpose(_CellposeSegmentation):
 
         self._clear_cache(vars_to_delete=[masks_nucleus, masks_cytosol])
 
-    def process(self, input_image):
+    def _execute_segmentation(self, input_image):
         # ensure the correct level is selected for the input image
         input_image = self._transform_input_image(input_image)
 
@@ -1521,7 +1521,7 @@ class CytosolSegmentationDownsamplingCellpose(CytosolSegmentationCellpose):
 
         return segmentation
 
-    def process(self, input_image):
+    def _execute_segmentation(self, input_image):
         # ensure the correct level is selected for the input image
         self._transform_input_image(input_image)
 
@@ -1741,7 +1741,7 @@ class CytosolOnly_Segmentation_Downsampling_Cellpose(CytosolOnlySegmentationCell
 
         return segmentation
 
-    def process(self, input_image) -> None:
+    def _execute_segmentation(self, input_image) -> None:
         # ensure the correct level is selected for the input image
         self._transform_input_image(input_image)
 


### PR DESCRIPTION
Currently not all workflows supported segmentation benchmarking. This resulted in errors with not-found variables in some cases. This PR fixes these issues.