### PR TITLE
Make downloading example datasets in non-editable install possible

### DIFF
--- a/src/scportrait/tools/ml/pretrained_models.py
+++ b/src/scportrait/tools/ml/pretrained_models.py
@@ -54,7 +54,7 @@ def get_data_dir() -> Path:
                 return parent
         return None
 
-    src_code_dir = find_root_by_file("README.md", Path(__file__))
+    src_code_dir = find_root_by_file("pyproject.toml", Path(__file__))
     if src_code_dir is None:
         raise FileNotFoundError("Could not find scPortrait root directory")
 

--- a/src/scportrait/tools/ml/pretrained_models.py
+++ b/src/scportrait/tools/ml/pretrained_models.py
@@ -48,18 +48,18 @@ def get_data_dir() -> Path:
         Path to data directory
     """
 
-    def find_root_by_file(marker_file: str, current_path: Path) -> Path | None:
+    def find_root_by_folder(marker_folder: str, current_path: Path) -> Path | None:
         for parent in current_path.parents:
-            print(parent)
-            if (parent / marker_file).exists():
+            if (parent / marker_folder).is_dir():
                 return parent
         return None
 
-    src_code_dir = find_root_by_file("README.md", Path(__file__))
-    if src_code_dir is None:
-        raise FileNotFoundError("Could not find scPortrait root directory")
+    src_code_dir = find_root_by_folder("io", Path(__file__))
 
+    if src_code_dir is None:
+        raise FileNotFoundError("Could not find scPortrait source directory")
     data_dir = src_code_dir / "scportrait_data"
+
     return data_dir.absolute()
 
 

--- a/src/scportrait/tools/ml/pretrained_models.py
+++ b/src/scportrait/tools/ml/pretrained_models.py
@@ -50,11 +50,12 @@ def get_data_dir() -> Path:
 
     def find_root_by_file(marker_file: str, current_path: Path) -> Path | None:
         for parent in current_path.parents:
+            print(parent)
             if (parent / marker_file).exists():
                 return parent
         return None
 
-    src_code_dir = find_root_by_file("pyproject.toml", Path(__file__))
+    src_code_dir = find_root_by_file("README.md", Path(__file__))
     if src_code_dir is None:
         raise FileNotFoundError("Could not find scPortrait root directory")
 


### PR DESCRIPTION
This PR fixes the issue #127 by changing the strategy of looking for README.md to io/ folder in the source code. During non-editable install, only the source code folder gets installed, making everything in the root dir of the repository invisible. This fix should be common for both install variants.