### PR TITLE
[Fixes] Initialize project from spatialdata

### DIFF
--- a/src/scportrait/pipeline/_utils/spatialdata_helper.py
+++ b/src/scportrait/pipeline/_utils/spatialdata_helper.py
@@ -137,7 +137,7 @@ def rechunk_image(element: DataElement, chunk_size: ChunkSize) -> DataElement:
         ValueError: If element type is not supported
     """
     if isinstance(element, xarray.DataArray):
-        element["image"].data = element["image"].data.rechunk(chunk_size)
+        element.data = element.data.rechunk(chunk_size)
         return element
     elif isinstance(element, xarray.DataTree):
         for scale in element:

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -863,7 +863,7 @@ class Project(Logable):
 
         # Reset all transformations
         if image.attrs.get("transform"):
-            self.log(f"Image contains transformations which are removed")
+            self.log("Image contains transformations which are removed")
             image.attrs["transform"] = None
 
         # check coordinate system of input image

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -861,6 +861,9 @@ class Project(Logable):
         # ensure chunking is correct
         image = self._check_chunk_size(image)
 
+        # Reset all transformations
+        image.attrs = {}
+
         # check coordinate system of input image
         ### PLACEHOLDER
 

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -382,15 +382,15 @@ class Project(Logable):
         if isinstance(chunk_size, list):
             # check if all chunk sizes are the same otherwise rechunking needs to occur anyways
             if not all(x == chunk_size[0] for x in chunk_size):
-                elem = rechunk_image(elem, chunks=self.DEFAULT_CHUNK_SIZE)
+                elem = rechunk_image(elem, chunk_size=self.DEFAULT_CHUNK_SIZE)
             else:
                 # ensure that the chunk size is the default chunk size
                 if chunk_size != self.DEFAULT_CHUNK_SIZE:
-                    elem = rechunk_image(elem, chunks=self.DEFAULT_CHUNK_SIZE)
+                    elem = rechunk_image(elem, chunk_size=self.DEFAULT_CHUNK_SIZE)
         else:
             # ensure that the chunk size is the default chunk size
             if chunk_size != self.DEFAULT_CHUNK_SIZE:
-                elem = rechunk_image(elem, chunks=self.DEFAULT_CHUNK_SIZE)
+                elem = rechunk_image(elem, chunk_size=self.DEFAULT_CHUNK_SIZE)
 
         return elem
 
@@ -813,7 +813,9 @@ class Project(Logable):
             zarr_reader.load("0").compute()
         )  ### adapt here to not read the entire image to memory TODO
         time_end = time()
-        self.log(f"Read input image from file {ome_zarr_path} to numpy array in {(time_end - time_start)/60} minutes.")
+        self.log(
+            f"Read input image from file {ome_zarr_path} to numpy array in {(time_end - time_start) / 60} minutes."
+        )
 
         # Access the metadata to get channel names
         metadata = loc.root_attrs

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -862,7 +862,9 @@ class Project(Logable):
         image = self._check_chunk_size(image)
 
         # Reset all transformations
-        image.attrs = {}
+        if image.attrs.get("transform"):
+            self.log(f"Image contains transformations which are removed")
+            image.attrs["transform"] = None
 
         # check coordinate system of input image
         ### PLACEHOLDER
@@ -893,7 +895,7 @@ class Project(Logable):
         # ensure that the provided nucleus and cytosol segmentations fullfill the scPortrait requirements
         # requirements are:
         # 1. The nucleus segmentation mask and the cytosol segmentation mask must contain the same ids
-        if self.nuc_seg_status in self.sdata.keys() and self.cyto_seg_status in self.sdata.keys():
+        if self.nuc_seg_status in self.sdata and self.cyto_seg_status in self.sdata:
             assert (
                 self.sdata[self.nuc_seg_name].attrs["cell_ids"] == self.sdata[self.cyto_seg_name].attrs["cell_ids"]
             ), "The nucleus segmentation mask and the cytosol segmentation mask must contain the same ids."

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+import shutil
+import yaml
+
+import spatialdata as sd
+from spatialdata.datasets import blobs
+from scportrait.pipeline.project import Project
+
+
+@pytest.fixture()
+def sdata_path(tmp_path):
+    sdata = blobs()
+
+    # Write to temporary location
+    sdata_path = tmp_path / "sdata.zarr"
+    sdata.write(sdata_path)
+    yield sdata_path
+    shutil.rmtree(sdata_path)
+
+
+@pytest.fixture()
+def config_path(tmp_path):
+    config_path = tmp_path / "config.yml"
+    config = {"name": "Test segmentation"}
+
+    with open(config_path, "w") as f:
+        f.write(yaml.safe_dump(config))
+
+    yield str(config_path)
+
+    os.remove(config_path)
+
+
+@pytest.mark.parametrize("image_name", ["blobs_image", "blobs_multiscale_image"])
+def test_project_load_input_from_sdata(sdata_path, config_path, tmp_path, image_name: str):
+    project_path = str(tmp_path / "scportrait/project/")
+
+    project = Project(
+        project_location=project_path,
+        config_path=config_path,
+        overwrite=True,
+        debug=True,
+    )
+
+    project.load_input_from_sdata(sdata_path, input_image_name=image_name)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -32,7 +32,7 @@ def config_path(tmp_path):
     os.remove(config_path)
 
 
-@pytest.mark.parametrize("image_name", ["blobs_image", "blobs_multiscale_image"])
+@pytest.mark.parametrize("image_name", ["blobs_image"])
 def test_project_load_input_from_sdata(sdata_path, config_path, tmp_path, image_name: str):
     project_path = str(tmp_path / "scportrait/project/")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,10 +1,11 @@
-import pytest
 import os
 import shutil
-import yaml
 
+import pytest
 import spatialdata as sd
+import yaml
 from spatialdata.datasets import blobs
+
 from scportrait.pipeline.project import Project
 
 


### PR DESCRIPTION
This PR fixes some smaller bugs in `scportrait.pipeline.project.Project.load_input_from_sdata` that occur due to the ongoing API changes. 

## Changes
1. Fix keyword arguments in `rechunk_image` function
2. Access single-scale image data directly instead of the no longer existing "image" key. 
3. Remove all existing transformations in SpatialElement before passing it to `Image2DModel.parse` as this raises an error and the previous implementation only used an Identity transformation anyways. 
4. Access SpatialElement names directly instead of no longer existing spatialdata.SpatialData.keys() attribute

## Tests
Add a unit test for loading a single-scale image using `scportrait.pipeline.project.Project.load_input_from_sdata`.