### PR TITLE
track segmentation metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ torch
 pytorch-lightning
 torchvision
 
-spatialdata>=0.2.0
+spatialdata>=0.3.0
 napari-spatialdata
 pyqt5
 lxml_html_clean

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,7 +29,7 @@ torch
 pytorch-lightning
 torchvision
 
-spatialdata>=0.2.0
+spatialdata>=0.3.0
 napari-spatialdata
 pyqt5
 lxml_html_clean


### PR DESCRIPTION
Given the new implementation of spatialdata.attrs this now allows us to track project related information in the sdata object itself. This PR implements the base requirements for incorporating this into scportrait and focuses on tracking segmentation related metadata.

Should address #148 