### PR TITLE
Update cellpose version to 3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tqdm
-numpy<2.0.0
+numpy
 pandas
 numba
 matplotlib
@@ -23,7 +23,7 @@ opencv-python
 scikit-image>=0.22.0
 scikit-fmm
 scipy
-cellpose<3.1.0
+cellpose>=3.1.1
 
 torch
 pytorch-lightning

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -23,7 +23,7 @@ opencv-python
 scikit-image>=0.22.0
 scikit-fmm
 scipy
-cellpose<3.1.0
+cellpose>=3.1.1
 
 torch
 pytorch-lightning


### PR DESCRIPTION
- in the new version of cellpose full M1 support is implemented, this fixes #106
- this also allows support for numpy 2.X on cell poses end and fixes #195