### PR TITLE
update Phenix Parser to work with HarmonyV7

### DIFF
--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -188,24 +188,36 @@ class PhenixParser:
                 tag = _get_child_name(child.tag)
                 if tag == "Row":
                     rows.append(child.text)
-                if tag == "Col":
+                    continue
+                elif tag == "Col":
                     cols.append(child.text)
-                if tag == "FieldID":
+                    continue
+                elif tag == "FieldID":
                     fields.append(child.text)
-                if tag == "PlaneID":
+                    continue
+                elif tag == "PlaneID":
                     planes.append(child.text)
-                if tag == "ChannelID":
+                    continue
+                elif tag == "ChannelID":
                     channel_ids.append(child.text)
-                if tag == "FlimID":
+                    continue
+                elif tag == "FlimID":
                     flim_ids.append(child.text)
-                if tag == "TimepointID":
+                    continue
+                elif tag == "TimepointID":
                     timepoints.append(child.text)
-                if tag == "PositionX":
+                    continue
+                elif tag == "PositionX":
                     x_positions.append(child.text)
-                if tag == "PositionY":
+                    continue
+                elif tag == "PositionY":
                     y_positions.append(child.text)
-                if tag == "AbsTime":
+                    continue
+                elif tag == "AbsTime":
                     times.append(child.text)
+                    continue
+                else:
+                    pass
 
         rows = [str(x).zfill(2) for x in rows]
         cols = [str(x).zfill(2) for x in cols]

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -254,7 +254,7 @@ class PhenixParser:
             ):
                 image_names.append(f"r{row}c{col}f{field}p{plane}-ch{channel_id}sk{timepoint}fk1fl{flim_id}.tiff")
         elif version == "HarmonyV7":
-            _timepoints = [str(x).zfill(2) for x in timepoints]
+            _timepoints = [str(x - 1).zfill(2) for x in timepoints]
             for (
                 row,
                 col,

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -213,6 +213,10 @@ class PhenixParser:
         planes = [str(x).zfill(2) for x in planes]
         timepoints = [int(x) + 1 for x in timepoints]
 
+        # get channelnames
+        lookup_dict = self.channel_lookup.set_index("id").to_dict()["label"]
+        channel_names = [lookup_dict[channel_id] for channel_id in channel_ids]
+
         image_names = []
         for row, col, field, plane, channel_id, timepoint, flim_id in zip(
             rows, cols, fields, planes, channel_ids, timepoints, flim_ids, strict=False

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -229,6 +229,7 @@ class PhenixParser:
         lookup_dict = self.channel_lookup.set_index("id").to_dict()["label"]
         channel_names = [lookup_dict[channel_id] for channel_id in channel_ids]
 
+        # generated image names have a different syntax between Harmony Versions
         image_names = []
         for row, col, field, plane, channel_id, timepoint, flim_id in zip(
             rows, cols, fields, planes, channel_ids, timepoints, flim_ids, strict=False

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -196,8 +196,6 @@ class PhenixParser:
                     planes.append(child.text)
                 if tag == "ChannelID":
                     channel_ids.append(child.text)
-                if tag == "ChannelName":
-                    channel_names.append(child.text)
                 if tag == "FlimID":
                     flim_ids.append(child.text)
                 if tag == "TimepointID":

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -254,6 +254,7 @@ class PhenixParser:
             ):
                 image_names.append(f"r{row}c{col}f{field}p{plane}-ch{channel_id}sk{timepoint}fk1fl{flim_id}.tiff")
         elif version == "HarmonyV7":
+            _timepoints = [str(x).zfill(2) for x in timepoints]
             for (
                 row,
                 col,
@@ -261,7 +262,7 @@ class PhenixParser:
                 plane,
                 channel_id,
                 timepoint,
-            ) in zip(rows, cols, fields, planes, channel_ids, timepoints, strict=False):
+            ) in zip(rows, cols, fields, planes, channel_ids, _timepoints, strict=False):
                 image_names.append(f"r{row}c{col}f{field}p{plane}-ch{channel_id}t{timepoint}.tiff")
 
         # convert date/time into useful format


### PR DESCRIPTION
fixes #179 

- code now automatically gets the Harmony Version from the provided XML file
- code is backwards compatible (parsing old Harmony 4.9 files functions exactly in the same way)
- noticed an irregularity in the generated Harmony XMLs: timepoints is denoted with a 2-based index under the XML key `TimepointID` but 1 based in the file naming convention → added a strange workaround where we subtract 1 from timepoints id to generate the expected file name to make everything match up 