### PR TITLE
Improve segmentation cellpose

### DIFF
--- a/examples/code_snippets/segmentation/run_seg_any_image.py
+++ b/examples/code_snippets/segmentation/run_seg_any_image.py
@@ -35,14 +35,8 @@ config = {
 method = CytosolOnlySegmentationCellpose(config=config)
 method.config = method.config["CytosolOnlySegmentationCellpose"]
 
-# create datastructure to save results to
-method.maps = {}
-
 # perform segmentation
-method.cellpose_segmentation(image)
-
-# access results
-seg_mask = method.maps["cytosol_segmentation"]
+seg_mask = method.cellpose_segmentation(image)
 
 # plot results
 plt.imshow(seg_mask)

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -1109,8 +1109,8 @@ class Project(Logable):
             if not self.segmentation_f.overwrite:
                 raise ValueError("Segmentation already exists. Set overwrite=True to overwrite.")
 
-        elif self.input_image is not None:
-            self.segmentation_f(self.input_image)
+        if self.input_image is not None:
+            self.segmentation_f.process(self.input_image)
 
         self.get_project_status()
         self.segmentation_f.overwrite = original_overwrite  # reset to original value

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -272,6 +272,9 @@ class Project(Logable):
                 from_project=True,
             )
 
+    def _update_segmentation_f(self, segmentation_f):
+        self._setup_segmentation_f(segmentation_f)
+
     def _setup_extraction_f(self, extraction_f):
         """Configure the extraction method for the project.
 
@@ -332,6 +335,25 @@ class Project(Logable):
                 from_project=True,
             )
 
+    def update_featurization_f(self, featurization_f):
+        """Update the featurization method chosen for the project without reinitializing the entire project.
+
+        Args:
+            featurization_f : The featurization method that should be used for the project.
+
+        Returns:
+            None : the featurization method is updated in the project object.
+
+        Examples:
+            Update the featurization method for a project::
+
+                from scportrait.pipeline.featurization import CellFeaturizer
+
+                project.update_featurization_f(CellFeaturizer)
+        """
+        self.log(f"Replacing current featurization method {self.featurization_f.__class__} with {featurization_f}")
+        self._setup_featurization_f(featurization_f)
+
     def _setup_selection(self, selection_f):
         """Configure the selection method for the project.
 
@@ -359,25 +381,6 @@ class Project(Logable):
                 filehandler=self.filehandler,
                 from_project=True,
             )
-
-    def update_featurization_f(self, featurization_f):
-        """Update the featurization method chosen for the project without reinitializing the entire project.
-
-        Args:
-            featurization_f : The featurization method that should be used for the project.
-
-        Returns:
-            None : the featurization method is updated in the project object.
-
-        Examples:
-            Update the featurization method for a project::
-
-                from scportrait.pipeline.featurization import CellFeaturizer
-
-                project.update_featurization_f(CellFeaturizer)
-        """
-        self.log(f"Replacing current featurization method {self.featurization_f.__class__} with {featurization_f}")
-        self._setup_featurization_f(featurization_f)
 
     ##### General small helper functions ####
 

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -543,6 +543,9 @@ class ShardedSegmentation(Segmentation):
         )
         self.segmentation_channels = test_method.segmentation_channels
 
+        if not hasattr(self, "_tmp_dir_path"):
+            self.create_temp_dir()
+
     def _check_config(self):
         super()._check_config()
 

--- a/src/scportrait/pipeline/segmentation/segmentation.py
+++ b/src/scportrait/pipeline/segmentation/segmentation.py
@@ -422,7 +422,6 @@ class Segmentation(ProcessingStep):
         input_image = input_image[
             :, self.window[0], self.window[1]
         ]  # for some segmentation workflows potentially only the first channel is required this is further selected down in that segmentation workflow
-        self.input_image = input_image  # track for potential plotting of intermediate results
 
         if self.deep_debug:
             self.log(

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -725,7 +725,7 @@ class _BaseSegmentation(Segmentation):
                 plot_results = True
 
             if plot_results:
-                if input_image is not None:
+                if input_image is None:
                     if "input_image" in self.__dict__.keys():
                         input_image = self.input_image
 

--- a/src/scportrait/pipeline/segmentation/workflows.py
+++ b/src/scportrait/pipeline/segmentation/workflows.py
@@ -612,10 +612,6 @@ class _BaseSegmentation(Segmentation):
 
             if plot_results:
                 # get input image for visualization
-                if input_image is None:
-                    if "input_image" in self.__dict__.keys():
-                        input_image = self.input_image
-
                 if input_image is not None:
                     if len(input_image.shape) == 2:
                         image_map = input_image
@@ -725,10 +721,6 @@ class _BaseSegmentation(Segmentation):
                 plot_results = True
 
             if plot_results:
-                if input_image is None:
-                    if "input_image" in self.__dict__.keys():
-                        input_image = self.input_image
-
                 if input_image is not None:
                     # convert input image from uint16 to uint8
                     input_image = (input_image / 256).astype(np.uint8)


### PR DESCRIPTION
- fixes #131, 
- fixes #209 
- improves run time of cellpose segmentation workflows by removing dependency on memory-mapping → assumption being available RAM is at least as big as the available GPU memory
