### PR TITLE
Improve log output during stitching

### DIFF
--- a/src/scportrait/__init__.py
+++ b/src/scportrait/__init__.py
@@ -22,3 +22,7 @@ warnings.filterwarnings("ignore", message="ignoring keyword argument 'read_only'
 warnings.filterwarnings(
     "ignore", message=r"You are using `torch.load` with `weights_only=False`.*", category=FutureWarning
 )
+
+
+# silence warning
+warnings.filterwarnings("ignore", category=FutureWarning, message="The plugin infrastructure in")

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from tifffile import imread, imwrite
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 def _get_child_name(elem):

--- a/src/scportrait/tools/stitch/_stitch.py
+++ b/src/scportrait/tools/stitch/_stitch.py
@@ -642,18 +642,12 @@ class ParallelStitcher(Stitcher):
         for i, channel in enumerate(self.channels):
             args.append((channel, i, hdf5_path))
 
-        tqdm_args = {
-            "file": sys.stdout,
-            "desc": "assembling mosaic",
-            "total": len(self.channels),
-        }
-
         # threading over channels is safe as the channels are written to different postions in the hdf5 file and do not interact with one another
         # threading over the writing of a single channel is not safe and leads to inconsistent results
         workers = np.min([self.threads, self.n_channels])
         print(f"assembling channels with {workers} workers")
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            list(tqdm(executor.map(self._assemble_channel, args), **tqdm_args))
+            list(executor.map(self._assemble_channel, args))
 
         # conver to dask array
         self.assembled_mosaic = dask_array_from_path(hdf5_path)

--- a/src/scportrait/tools/stitch/_stitch.py
+++ b/src/scportrait/tools/stitch/_stitch.py
@@ -18,7 +18,7 @@ from alphabase.io.tempmmap import (
     mmap_array_from_path,
     redefine_temp_location,
 )
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from scportrait.io.daskmmap import dask_array_from_path
 from scportrait.processing.images._image_processing import rescale_image


### PR DESCRIPTION
limit the number of print statements made during multi-threaded stitching to not overload the log file.
Now the progress bar is only updated every 10% interval steps

fixes #142 