### PR TITLE
improve handling of empty spatialdata files to make use of overwrite more robust

### DIFF
--- a/src/scportrait/pipeline/_utils/sdata_io.py
+++ b/src/scportrait/pipeline/_utils/sdata_io.py
@@ -54,6 +54,22 @@ class sdata_filehandler(Logable):
         self.cyto_seg_name = cyto_seg_name
         self.centers_name = centers_name
 
+    def _check_empty_sdata(self) -> bool:
+        """Check if SpatialData object is empty.
+
+        Returns:
+            Whether SpatialData object is empty
+        """
+        empty_sdata_keys = {".zattrs", ".zgroup", "zmetadata"}
+        if os.path.exists(self.sdata_path):
+            keys = set(os.listdir(self.sdata_path))
+            if keys == empty_sdata_keys:
+                return True
+            else:
+                return False
+        else:
+            return True
+
     def _create_empty_sdata(self) -> SpatialData:
         """Create an empty SpatialData object.
 
@@ -76,7 +92,7 @@ class sdata_filehandler(Logable):
             SpatialData object
         """
         if os.path.exists(self.sdata_path):
-            if len(os.listdir(self.sdata_path)) == 0:
+            if self._check_empty_sdata():
                 shutil.rmtree(self.sdata_path, ignore_errors=True)
                 _sdata = self._create_empty_sdata()
                 _sdata.write(self.sdata_path, overwrite=True)

--- a/src/scportrait/pipeline/_utils/sdata_io.py
+++ b/src/scportrait/pipeline/_utils/sdata_io.py
@@ -92,12 +92,7 @@ class sdata_filehandler(Logable):
             SpatialData object
         """
         if os.path.exists(self.sdata_path):
-            if self._check_empty_sdata():
-                shutil.rmtree(self.sdata_path, ignore_errors=True)
-                _sdata = self._create_empty_sdata()
-                _sdata.write(self.sdata_path, overwrite=True)
-            else:
-                _sdata = SpatialData.read(self.sdata_path)
+            _sdata = SpatialData.read(self.sdata_path)
 
         else:
             _sdata = self._create_empty_sdata()

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -471,13 +471,12 @@ class Project(Logable):
 
         if os.path.exists(self.sdata_path):
             if self.overwrite:
-                self.log(f"Output location {self.sdata_path} already exists. Overwriting.")
-                shutil.rmtree(self.sdata_path, ignore_errors=True)
+                if not self.filehandler._check_empty_sdata():
+                    self.log(f"Output location {self.sdata_path} already exists. Overwriting.")
+                    shutil.rmtree(self.sdata_path, ignore_errors=True)
             else:
                 # check to see if the sdata object is empty
-                if self.filehandler._check_empty_sdata():
-                    shutil.rmtree(self.sdata_path, ignore_errors=True)
-                else:
+                if not self.filehandler._check_empty_sdata():
                     raise ValueError(
                         f"Output location {self.sdata_path} already exists. Set overwrite=True to overwrite."
                     )

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -35,10 +35,8 @@ from scportrait.pipeline._base import Logable
 from scportrait.pipeline._utils.helper import read_config
 from scportrait.pipeline._utils.sdata_io import sdata_filehandler
 from scportrait.pipeline._utils.spatialdata_helper import (
-    calculate_centroids,
     generate_region_annotation_lookuptable,
     get_chunk_size,
-    get_unique_cell_ids,
     rechunk_image,
     remap_region_annotation_table,
 )
@@ -477,10 +475,7 @@ class Project(Logable):
                 shutil.rmtree(self.sdata_path, ignore_errors=True)
             else:
                 # check to see if the sdata object is empty
-                if len(os.listdir(self.sdata_path)) == 0:
-                    self.log(
-                        f"Output location {self.sdata_path} already exists but does not contain any data. Overwriting."
-                    )
+                if self.filehandler._check_empty_sdata():
                     shutil.rmtree(self.sdata_path, ignore_errors=True)
                 else:
                     raise ValueError(


### PR DESCRIPTION
- addresses #168 
- implements a check for an empty spatialdata object that ensures that no error is raised when something is added to the empty object even though overwrite is set to False
