### PR TITLE
ADDED: alignment function for DAPI across different cycles

### DIFF
--- a/src/scportrait/tools/stitch/_utils/alignment.py
+++ b/src/scportrait/tools/stitch/_utils/alignment.py
@@ -1,0 +1,48 @@
+from skimage.registration import phase_cross_correlation
+from scipy.ndimage import fourier_shift
+import numpy as np
+
+def apply_shift(target_img, shift):
+    """
+    Apply a Fourier shift to the target image.
+
+    This function shifts the input image in the Fourier domain by the specified amount
+    and returns the corrected image. This image is usually another staining from another cycle.
+
+    Parameters:
+    target_img (numpy.ndarray): The input image to be shifted.
+    shift (array-like): The amount of shift to apply to the image. This should be an array-like
+                        object with the same number of dimensions as the target image.
+
+    Returns:
+    tuple: A tuple containing:
+        - corrected_image (numpy.ndarray): The shifted image.
+        - shift (array-like): The applied shift.
+    """
+    corrected_image = fourier_shift(np.fft.fftn(target_img), np.array(shift))
+    corrected_image = np.fft.ifftn(corrected_image).real  # Take real part
+    return corrected_image
+
+
+def get_registered_img(source_img, target_img, normalize_images=True):
+    """
+    Registers the target image to the source image using phase cross-correlation. This function is based on
+    https://scikit-image.org/docs/0.23.x/auto_examples/registration/plot_register_translation.html#sphx-glr-auto-examples-registration-plot-register-translation-py.
+
+    The function expects 2 grayscale images of the same size. The target image will be registered to the source image
+    by applying a shift. The shift is calculated using phase cross-correlation. Shift is returned to be applied on other stainings of the same cycle of the target_img.
+    Parameters:
+    source_img (numpy.ndarray): The source image to which the target image will be registered. Usually the DAPI staining of a cycle.
+    target_img (numpy.ndarray): The target image that will be registered to the source image. DAPI staining of another cycle.
+    normalize_images (bool): If True, normalize the images to the range [0, 1] before registration.
+
+    Returns:
+    numpy.ndarray: The registered (corrected) target image.
+    numpy.ndarray: The shift vector that was applied to the target image.
+    """
+    if normalize_images:
+        source_img = (source_img - source_img.min()) / (source_img.max() - source_img.min())
+        target_img = (target_img - target_img.min()) / (target_img.max() - target_img.min())
+    shift, error, diffphase = phase_cross_correlation(source_img, target_img, upsample_factor=100)
+    corrected_image = apply_shift(target_img, shift)
+    return corrected_image, shift


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [ x] This comment contains a description of changes (with reason)
- [ x] Referenced issue is linked
- [ ] Documentation in `docs` is updated

**Description of changes**

One common problem in fluorescent imaging (especially in 4i) across different cycles is the shifting of the samples, known as the registration problem. This function finds the shift across two given channels (mostly DAPI) of the same sample from 2 different cycles and matches the target image on the source image by shifting the target image. 

**Technical details**

Images are first transformed onto frequency space by a Fourier transform. Following this, the cross power spectrum (cps) is computed, which models the change in amplitude as well as the phase among these two Fourier transformed images. The normalized cps is then rewritten with the help of Fourier shift theorem and transformed back to the original image space by the inverse Fourier transform, in which the maximum values yield the shift in Y and X dimensions. The shift is then applied to the target image, aligning it onto the source image. This shift can then be used across different dyes from these two cycles to correct all of the remaining channels. This is motivated by the example: https://scikit-image.org/docs/0.23.x/auto_examples/registration/plot_register_translation.html#sphx-glr-auto-examples-registration-plot-register-translation-py 


**Additional context**

A ppp describing the problem and motivating the solution.
[Registration Presentation.pptx](https://github.com/user-attachments/files/19103027/Registration.Presentation.pptx)
