### PR TITLE
Run CI on PRs

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,6 +1,13 @@
 name: Perform Unit Test
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
 
 jobs:
   build-linux:


### PR DESCRIPTION
Earlier, CI was only run on push events. Since all developers are contributors and pushed to branches on this repository, the push event was triggered. However, this does not apply to people contributing from forks who do not trigger push events.

The new setup also runs the CI when:

1. Labels are changed. We can remove this but if you ever want GPU CI and a GPU label, this can come in handy.
2. PR are opened
3. PRs are updated