### PR TITLE
properly preserve channel names when loading from sdata

### DIFF
--- a/src/scportrait/pipeline/_utils/sdata_io.py
+++ b/src/scportrait/pipeline/_utils/sdata_io.py
@@ -205,8 +205,6 @@ class sdata_filehandler(Logable):
         else:
             if scale_factors is None:
                 scale_factors = [2, 4, 8]
-            if scale_factors is None:
-                scale_factors = [2, 4, 8]
 
             if isinstance(image, xarray.DataArray):
                 # if so first validate the model since this means we are getting the image from a spatialdata object already
@@ -221,6 +219,7 @@ class sdata_filehandler(Logable):
                 image = Image2DModel.parse(
                     image,
                     scale_factors=scale_factors,
+                    c_coords=channel_names,
                     rgb=False,
                 )
 


### PR DESCRIPTION
Fix for channel_names writing in _write_image_sdata() when passing channel_names through project.load_input_from_sdata()
+ additional double code removal of scale_factors


