### PR TITLE
Improve centroid calculation performance

### DIFF
--- a/src/scportrait/pipeline/_utils/segmentation.py
+++ b/src/scportrait/pipeline/_utils/segmentation.py
@@ -14,9 +14,8 @@ from skimage.morphology import dilation as sk_dilation
 from skimage.segmentation import watershed
 from skimage.transform import resize
 
+from scportrait.pipeline._utils.constants import DEFAULT_SEGMENTATION_DTYPE
 from scportrait.plotting.vis import plot_image
-
-DEFAULT_SEGMENTATION_DTYPE = np.uint32
 
 
 def global_otsu(image: NDArray) -> float:
@@ -603,7 +602,7 @@ def numba_mask_centroid(
 
     num_classes = int(np.max(mask) if skip_background else np.max(mask) + 1)
 
-    points_class = np.zeros((num_classes,), dtype=nb.uint32)
+    points_class = np.zeros((num_classes,), dtype=nb.uint64)
     center = np.zeros((num_classes, 2))
     ids = np.full((num_classes,), np.nan)
 
@@ -638,7 +637,7 @@ def numba_mask_centroid(
     points_class = points_class[bg_mask]
     ids = ids[bg_mask]
 
-    return center, points_class, ids.astype(np.uint32)
+    return center, points_class, ids.astype(DEFAULT_SEGMENTATION_DTYPE)
 
 
 @nb.jit(nopython=True)

--- a/src/scportrait/pipeline/_utils/segmentation.py
+++ b/src/scportrait/pipeline/_utils/segmentation.py
@@ -357,7 +357,7 @@ def shift_labels(
             _edge_label = [label + shift for label in edge_label]
             shifted_map = np.where(np.isin(shifted_map, _edge_label), 0, shifted_map)
 
-    return shifted_map.astype(np.uint32), list(set(edge_label))
+    return shifted_map.astype(DEFAULT_SEGMENTATION_DTYPE), list(set(edge_label))
 
 
 @njit(parallel=True)
@@ -589,11 +589,10 @@ def numba_mask_centroid(
         >>> mask = np.array([[0, 1, 1], [0, 2, 1], [0, 0, 2]])
         >>> centers, sizes, ids = numba_mask_centroid(mask)
     """
-    cell_ids = list(np.unique(mask).flatten())
+    cell_ids = np.unique(mask).flatten()
     if skip_background:
         if 0 in cell_ids:
-            cell_ids.remove(0)
-    cell_ids = np.array(cell_ids)
+            cell_ids = cell_ids[1:]
 
     min_cell_id = np.min(cell_ids)
 

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -351,10 +351,11 @@ class HDF5CellExtraction(ProcessingStep):
     def _get_input_image_info(self) -> None:
         """get relevant information about the input image to be able to extract single-cell images"""
         # get channel information
-        self.channel_names = self.project.input_image.c.values
+        input_image = self.filehandler._get_input_image(self.filehandler.get_sdata())
+        self.channel_names = input_image.c.values
         self.n_image_channels = len(self.channel_names)
-        self.input_image_width = len(self.project.input_image.x)
-        self.input_image_height = len(self.project.input_image.y)
+        self.input_image_width = len(input_image.x)
+        self.input_image_height = len(input_image.y)
 
     def _get_centers(self) -> None:
         """get the centers of the cells that should be extracted.

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -335,18 +335,18 @@ class HDF5CellExtraction(ProcessingStep):
             # perform sanity check that the masks have the same ids
             # THIS NEEDS TO BE IMPLEMENTED HERE
 
-            self.main_segmenation_mask = self.nucleus_key
+            self.main_segmentation_mask = self.nucleus_key
 
         elif self.n_masks == 1:
             if self.extract_nucleus_mask:
-                self.main_segmenation_mask = self.nucleus_key
+                self.main_segmentation_mask = self.nucleus_key
             elif self.extract_cytosol_mask:
-                self.main_segmenation_mask = self.cytosol_key
+                self.main_segmentation_mask = self.cytosol_key
 
         self.log(
             f"Found {self.n_masks} segmentation masks for the given key in the sdata object. Will be extracting single-cell images based on these masks: {self.masks}"
         )
-        self.log(f"Using {self.main_segmenation_mask} as the main segmentation mask to determine cell centers.")
+        self.log(f"Using {self.main_segmentation_mask} as the main segmentation mask to determine cell centers.")
 
     def _get_input_image_info(self) -> None:
         """get relevant information about the input image to be able to extract single-cell images"""
@@ -364,9 +364,9 @@ class HDF5CellExtraction(ProcessingStep):
         _sdata = self.filehandler._read_sdata()
 
         # calculate centers if they have not been calculated yet
-        centers_name = f"{self.DEFAULT_CENTERS_NAME}_{self.main_segmenation_mask}"
+        centers_name = f"{self.DEFAULT_CENTERS_NAME}_{self.main_segmentation_mask}"
         if centers_name not in _sdata:
-            self.filehandler._add_centers(self.main_segmenation_mask, overwrite=self.overwrite)
+            self.filehandler._add_centers(self.main_segmentation_mask, overwrite=self.overwrite)
             _sdata = self.filehandler._read_sdata()  # reread to ensure we have updated version
 
         centers = _sdata[centers_name].values.compute()

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -613,6 +613,17 @@ class HDF5CellExtraction(ProcessingStep):
             mask = binary_fill_holes(mask)
             mask = gaussian(mask, preserve_range=True, sigma=1)
 
+            if self.deep_debug:
+                if mask.shape != (self.extracted_image_size, self.extracted_image_size):
+                    print("Width of window_x", window_x.stop - window_x.start)
+                    print("Width of window_y", window_y.stop - window_y.start)
+                    print("Width of mask", mask.shape)
+                    print("px_center", px_center)
+                    print("cell_id", ids[mask_ix])
+            assert mask.shape == (
+                self.extracted_image_size,
+                self.extracted_image_size,
+            ), "Mask shape does not match extracted image size."
             masks.append(mask)
 
         # get the image data

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -595,8 +595,7 @@ class HDF5CellExtraction(ProcessingStep):
             px_center[1] < self.input_image_height - self.width_extraction,
         ]
         if not condition:
-            msg = "Cell is too close to the image edge to be extracted."
-            raise ValueError(msg)  # or a custom error
+            raise ValueError("Cell is too close to the image edge to be extracted.")
 
         masks = []
 

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -540,11 +540,7 @@ class HDF5CellExtraction(ProcessingStep):
         """
 
         # define path where classes should be saved
-        filtered_path = os.path.join(
-            self.project_location,
-            self.DEFAULT_EXTRACTION_DIR_NAME,
-            self.DEFAULT_REMOVED_CLASSES_FILE,
-        )
+        filtered_path = os.path.join(self.extraction_data_directory, self.DEFAULT_REMOVED_CLASSES_FILE)
 
         to_write = "\n".join([str(i) for i in list(classes)])
 

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -1567,7 +1567,14 @@ class Project(Logable):
         self.get_project_status()
         self.segmentation_f.overwrite = original_overwrite  # reset to original value
 
-    def extract(self, partial=False, n_cells=None, seed: int = 42, overwrite: bool | None = None) -> None:
+    def extract(
+        self,
+        partial=False,
+        n_cells=None,
+        seed: int = 42,
+        overwrite: bool | None = None,
+        output_folder_name: str | None = None,
+    ) -> None:
         """Extract single-cell images from the input image using the defined extraction method.
 
         Args:
@@ -1576,6 +1583,7 @@ class Project(Logable):
             seed: Seed for the random number generator during a partial extraction. Default is ``42``.
             overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading
+            output_folder_name: can be set to override the default output folder location.
 
         Returns:
             None: Single-cell images are written to HDF5 files in the project associated extraction directory. File path can be accessed via ``project.extraction_f.output_path``.
@@ -1594,7 +1602,7 @@ class Project(Logable):
         if overwrite is not None:
             self.extraction_f.overwrite_run_path = overwrite
 
-        self.extraction_f(partial=partial, n_cells=n_cells, seed=seed)
+        self.extraction_f(partial=partial, n_cells=n_cells, seed=seed, output_folder_name=output_folder_name)
         self.get_project_status()
 
     def featurize(

--- a/src/scportrait/tools/sdata/processing/_subset.py
+++ b/src/scportrait/tools/sdata/processing/_subset.py
@@ -1,7 +1,9 @@
 import spatialdata
 
 
-def get_bounding_box_sdata(sdata: spatialdata, max_width: int, center_x: int, center_y: int) -> spatialdata:
+def get_bounding_box_sdata(
+    sdata: spatialdata, max_width: int, center_x: int, center_y: int, drop_points: bool = True
+) -> spatialdata:
     """apply bounding box to sdata object
 
     Args:
@@ -15,10 +17,11 @@ def get_bounding_box_sdata(sdata: spatialdata, max_width: int, center_x: int, ce
     """
 
     # remove points object to improve subsetting
-    points_keys = list(sdata.points.keys())
-    if len(points_keys) > 0:
-        for x in points_keys:
-            del sdata.points[x]
+    if drop_points:
+        points_keys = list(sdata.points.keys())
+        if len(points_keys) > 0:
+            for x in points_keys:
+                del sdata.points[x]
 
     width = max_width // 2
 

--- a/src/scportrait/tools/sdata/write/_helper.py
+++ b/src/scportrait/tools/sdata/write/_helper.py
@@ -79,11 +79,12 @@ def _force_delete_object(sdata: SpatialData, name: str) -> None:
     Returns:
         None the SpatialData object is updated on file
     """
+    in_memory_only, _ = sdata._symmetric_difference_with_zarr_store()
+    in_memory_only = [x.split("/")[-1] for x in in_memory_only]
+
     if name in sdata:
         del sdata[name]
 
-    in_memory_only, _ = sdata._symmetric_difference_with_zarr_store()
-    in_memory_only = [x.split("/")[-1] for x in in_memory_only]
     if name not in in_memory_only:
         sdata.delete_element_from_disk(name)
 

--- a/tests/unit_tests/pipeline/test_pipeline_utils_segmentation.py
+++ b/tests/unit_tests/pipeline/test_pipeline_utils_segmentation.py
@@ -207,9 +207,24 @@ def test_numba_mask_centroid():
     mask = np.array([[0, 1, 1], [0, 2, 1], [0, 0, 2]])
     centers, points_class, ids = numba_mask_centroid(mask)
     expected_centers = np.array([[0.33333333, 1.66666667], [1.5, 1.5]])
-    expected_points_class = np.array([3, 2], dtype=np.uint32)
+    expected_points_class = np.array([3, 2], dtype=np.uint64)
     expected_ids = np.array([1, 2], dtype=int)
 
     assert np.allclose(centers, expected_centers, atol=1e-6)
     assert np.all(points_class == expected_points_class)
     assert np.all(ids == expected_ids)
+
+
+def test_numba_mask_centroid_shifted():
+    mask = np.array([[0, 1, 1], [0, 2, 1], [0, 0, 2]])
+    shift = 10
+    centers, points_class, ids = numba_mask_centroid(mask)
+    expected_centers = np.array([[0.33333333, 1.66666667], [1.5, 1.5]])
+    expected_points_class = np.array([3, 2], dtype=np.uint64)
+    shifted_mask = shift_labels(mask, shift, remove_edge_labels=False)[0]
+    shifted_centers, shifted_points_class, shifted_ids = numba_mask_centroid(shifted_mask)
+
+    assert np.allclose(shifted_centers, centers, atol=1e-6)
+    assert np.allclose(shifted_centers, expected_centers, atol=1e-6)
+    assert np.all(shifted_points_class == points_class)
+    assert np.all(shifted_points_class == expected_points_class)


### PR DESCRIPTION
 one larger datasets the memory requirements for computing the centroids with the numba accelerated functions increase dramatically if the cell_ids do not start at 1 and increase sequentially.

This addresses this issue to try and allow for the using of the numba acceralted functions over a larger subset of datasets before needing to revert to the dark-backed function get_centroids() that is much slower.