### PR TITLE
[FIX] ensure spatialdata.attrs are only modified on disk when required

### DIFF
--- a/src/scportrait/pipeline/_utils/sdata_io.py
+++ b/src/scportrait/pipeline/_utils/sdata_io.py
@@ -107,7 +107,6 @@ class sdata_filehandler(Logable):
         else:
             _sdata = self._create_empty_sdata()
             _sdata.write(self.sdata_path, overwrite=True)
-
         return _sdata
 
     def get_sdata(self) -> SpatialData:
@@ -150,7 +149,7 @@ class sdata_filehandler(Logable):
         self.nuc_centers_status = f"{self.centers_name}_{self.nuc_seg_name}" in _sdata.points
         self.cyto_centers_status = f"{self.centers_name}_{self.cyto_seg_name}" in _sdata.points
 
-        _sdata.attrs["sdata_status"] = {
+        updated_attrs = {
             "input_images": self.input_image_status,
             "nucleus_segmentation": self.nuc_seg_status,
             "cytosol_segmentation": self.cyto_seg_status,
@@ -158,8 +157,17 @@ class sdata_filehandler(Logable):
             "cytosol_centers": self.cyto_centers_status,
         }
 
-        _sdata.write_metadata()  # ensure the metadata is updated on file
+        # only update attrs on file if necessary to prevent potential data corruption due to no file space
+        if not updated_attrs == _sdata.attrs["sdata_status"]:
+            _sdata.attrs["sdata_status"] = {
+                "input_images": self.input_image_status,
+                "nucleus_segmentation": self.nuc_seg_status,
+                "cytosol_segmentation": self.cyto_seg_status,
+                "nucleus_centers": self.nuc_centers_status,
+                "cytosol_centers": self.cyto_centers_status,
+            }
 
+            _sdata.write_metadata()  # ensure the metadata is updated on file
         if return_sdata:
             return _sdata
         return None


### PR DESCRIPTION
fixes #300

Test code:

``` python
def _check_mod_time(file_path):
    import os
    import datetime

    mod_time = os.path.getmtime(file_path)
    mod_time_readable = datetime.datetime.fromtimestamp(mod_time)

    print(mod_time_readable)
    return(mod_time_readable)

project_location = "project_folder"
_check_mod_time(f"{project_location}/scportrait.sdata/.zattrs")
project = Project(
    os.path.abspath(project_location),
    config_path="config_example1.yml",
    overwrite=True,
    debug=False,
    segmentation_f=CytosolSegmentationCellpose,
    extraction_f=HDF5CellExtraction,
)
_check_mod_time(f"{project_location}/scportrait.sdata/.zattrs")
```

Before implementation of fix, modification time was always updated upon project initialisation:

```
2025-05-27 09:35:42.651270
2025-05-27 10:13:59.915119
```

After fix:

```
2025-05-27 10:13:59.915119
2025-05-27 10:13:59.915119
```
