### PR TITLE
[FIX] ensure that no nan values are returned during center calculation

### DIFF
--- a/src/scportrait/pipeline/_utils/segmentation.py
+++ b/src/scportrait/pipeline/_utils/segmentation.py
@@ -1,5 +1,7 @@
 """Functions for thresholding and segmenting images."""
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numba as nb
 import numpy as np
@@ -626,11 +628,7 @@ def numba_mask_centroid(
                 center[class_id] += np.array([x, y])
                 ids[class_id] = class_id
 
-    x = center[:, 0] / points_class
-    y = center[:, 1] / points_class
-    center = np.stack((y, x)).T
-
-    # Remove background and invalid IDs
+    # remove background and invalid IDs before computing centers
     valid_mask = ~np.isnan(ids)
     center = center[valid_mask]
     points_class = points_class[valid_mask]
@@ -640,6 +638,30 @@ def numba_mask_centroid(
     center = center[bg_mask]
     points_class = points_class[bg_mask]
     ids = ids[bg_mask]
+
+    # check for any classes that have 0 pixels to ensure that a division by 0 does not occur
+    safe_mask = points_class > 0
+    if not np.all(safe_mask):
+        warnings.warn("Some classes had zero pixels and were removed.", stacklevel=2)
+
+        # filtering only needs to be performed if there is a value that is not correct
+        points_class = points_class[safe_mask]
+        center = center[safe_mask]
+        ids = ids[safe_mask]
+
+    x = center[:, 0] / points_class
+    y = center[:, 1] / points_class
+    center = np.stack((y, x)).T
+
+    # ensure no NaN values are left
+    valid_mask = ~np.isnan(ids) & ~np.isnan(center).any(axis=1)
+    if not np.all(valid_mask):
+        warnings.warn("NaN values encountered in centroid calculation and removed.", stacklevel=2)
+
+        # filtering only needs to be performed if there is a value that is not correct
+        center = center[valid_mask]
+        points_class = points_class[valid_mask]
+        ids = ids[valid_mask]
 
     return center, points_class, ids.astype(DEFAULT_SEGMENTATION_DTYPE)
 


### PR DESCRIPTION
- fixes #318 
- reduces centers to be calculated before division by px-size (prevents division by zero)
- raises warnings in case unexpected nan values are encountered, these are filtered out though