### PR TITLE
Switched from tuple to list in config example

### DIFF
--- a/docs/pages/workflow/config.rst
+++ b/docs/pages/workflow/config.rst
@@ -27,7 +27,7 @@ methods chosen in a specific scPortrait Project run.
         threads: 80 # threads used in multithreading
         image_size: 128 # image size in pixel
         normalize_output: True
-        normalization_range: (0.01, 0.99)
+        normalization_range: [0.01, 0.99]
         cache: "."
     CellFeaturizer:
         batch_size: 900


### PR DESCRIPTION
The `config.yml` example in the docs used a tuple to specify normalization quantiles. This was parsed as a string, which lead to an `AssertionError` about its maximum length.