### PR TITLE
[FIX] reduce peak memory usage during single-cell extraction

### DIFF
--- a/docs/pages/tutorials.rst
+++ b/docs/pages/tutorials.rst
@@ -22,6 +22,8 @@ This notebook walks you through the currently implemented segmentation workflows
 
    notebooks/_notebook_segmentation_workflows.nblink
 
+.. _single_cell_extraction_tutorial:
+
 Fine-tuning the single-cell image extraction
 --------------------------------------------
 

--- a/docs/pages/workflow/config.rst
+++ b/docs/pages/workflow/config.rst
@@ -29,6 +29,7 @@ methods chosen in a specific scPortrait Project run.
         normalize_output: True
         normalization_range: [0.01, 0.99]
         cache: "."
+        target_ram_utilization: 0.85 # fraction of total system RAM the extraction job should target
     CellFeaturizer:
         batch_size: 900
         dataloader_worker_number: 10 #needs to be 0 if using cpu
@@ -49,3 +50,31 @@ methods chosen in a specific scPortrait Project run.
         path_optimization: "hilbert"
         greedy_k: 15
         hilbert_p: 7
+
+For ``HDF5CellExtraction``, scPortrait can run multiple worker processes to prepare
+single-cell image batches while the main process writes results to the output HDF5
+file. On large datasets, preparing batches can be faster than writing them to
+disk, which would otherwise allow completed batch results to accumulate in
+memory. To keep this manageable, the extraction workflow can limit how many
+completed batch results are buffered in memory at the same time.
+
+When ``max_inflight_result_batches`` is not provided explicitly, scPortrait
+calibrates it automatically from the first wave of worker batches together with the
+configured ``target_ram_utilization``. This calibration estimates worker memory
+overhead and returned batch payload size, then chooses an in-flight batch limit
+that aims to stay within the requested RAM budget for the job.
+
+If the RAM budget would imply a value smaller than the active worker count,
+scPortrait keeps the in-flight batch limit at least as large as the number of
+workers and emits a warning in the log. In that case, the correct way to reduce
+memory further is to lower ``threads``.
+
+``flush_every`` controls how often the output HDF5 file is flushed and garbage
+collection is run during extraction. If it is not configured explicitly,
+scPortrait derives it automatically from the effective in-flight batch limit.
+
+Normalization settings are also important because they directly affect the
+extracted single-cell image values used downstream. If you need guidance on
+choosing ``normalize_output`` or ``normalization_range``, refer to the tutorial
+notebook "Fine-tuning the single-cell image extraction" in the tutorials
+section.

--- a/docs/pages/workflow/config.rst
+++ b/docs/pages/workflow/config.rst
@@ -60,8 +60,8 @@ completed batch results are buffered in memory at the same time.
 
 When ``max_inflight_result_batches`` is not provided explicitly, scPortrait
 calibrates it automatically from the first wave of worker batches together with the
-configured ``target_ram_utilization``. This calibration estimates worker memory
-overhead and returned batch payload size, then chooses an in-flight batch limit
+configured ``target_ram_utilization``. This calibration estimates returned batch
+payload size together with the parent-process RSS, then chooses an in-flight batch limit
 that aims to stay within the requested RAM budget for the job.
 
 If the RAM budget would imply a value smaller than the active worker count,

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -1012,15 +1012,30 @@ class HDF5CellExtraction(ProcessingStep):
             with mp.Manager() as manager:
                 lock = manager.Lock()  # Create lock via Manager to enable sharing
 
+                self.log("Initializing multiprocessing pool for extraction.")
                 with mp.get_context("fork").Pool(
                     processes=self.threads
                 ) as pool:  # both spawn and fork work but fork is faster so forcing fork here
-                    for result in tqdm(
-                        pool.imap_unordered(self._extract_classes_multi, args),
-                        total=len(args),
-                        desc="Extracting cell batches",
-                    ):
-                        self._write_to_hdf5(result, lock)
+                    iterator = pool.imap_unordered(self._extract_classes_multi, args)
+                    if len(args) > 0:
+                        self.log("Workers initialized. Waiting for first completed extraction batch...")
+                        wait_start = timeit.default_timer()
+                        first_result = next(iterator)
+                        first_wait_s = timeit.default_timer() - wait_start
+                        self.log(f"First batch received after {first_wait_s:.2f} seconds.")
+
+                        write_start = timeit.default_timer()
+                        self._write_to_hdf5(first_result, lock)
+                        first_write_s = timeit.default_timer() - write_start
+                        self.log(f"First batch written to HDF5 in {first_write_s:.2f} seconds.")
+
+                        with tqdm(total=len(args), initial=1, desc="Extracting cell batches") as pbar:
+                            for _ in range(len(args) - 1):
+                                result = next(iterator)
+
+                                self._write_to_hdf5(result, lock)
+
+                                pbar.update(1)
                     pool.close()
                     pool.join()
 

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -1,7 +1,6 @@
 import gc
 import multiprocessing as mp
 import os
-import pickle
 import platform
 import shutil
 import sys
@@ -9,6 +8,7 @@ import time
 import timeit
 from functools import partial as func_partial
 from pathlib import PosixPath
+from typing import TypeAlias
 
 import h5py
 import matplotlib.pyplot as plt
@@ -27,6 +27,9 @@ from scportrait.pipeline._base import ProcessingStep
 from scportrait.pipeline._utils.helper import flatten
 from scportrait.processing.images._image_processing import percentile_normalization
 from scportrait.tools.sdata.write._helper import _normalize_anndata_strings
+
+ExtractionArg: TypeAlias = tuple[int, int, int, tuple[float, float]]
+BatchedExtractionArgs: TypeAlias = list[list[ExtractionArg]]
 
 
 class HDF5CellExtraction(ProcessingStep):
@@ -901,11 +904,8 @@ class HDF5CellExtraction(ProcessingStep):
     def _estimate_returned_result_bytes(self, results: list[tuple[int, np.ndarray, int]]) -> int:
         """Estimate memory footprint of a returned multiprocessing batch payload."""
         array_bytes = sum(int(stack.nbytes) for _, stack, _ in results)
-        try:
-            serialized_bytes = len(pickle.dumps(results, protocol=pickle.HIGHEST_PROTOCOL))
-        except (pickle.PicklingError, TypeError, AttributeError):
-            serialized_bytes = 0
-        return max(array_bytes, serialized_bytes)
+        container_bytes = sys.getsizeof(results) + sum(sys.getsizeof(result) for result in results)
+        return array_bytes + container_bytes
 
     def _get_target_job_ram_bytes(self) -> int:
         """Return the configured total RAM budget for this extraction job."""
@@ -999,7 +999,7 @@ class HDF5CellExtraction(ProcessingStep):
     def _iter_completed_batch_results(
         self,
         pool: mp.pool.Pool,
-        args: list[list[tuple[np.ndarray, int, int, np.ndarray, int]]],
+        args: BatchedExtractionArgs,
         max_inflight_result_batches: int,
         pending_results: list | None = None,
         next_submit_ix: int = 0,
@@ -1068,7 +1068,7 @@ class HDF5CellExtraction(ProcessingStep):
     def _calibrate_max_inflight_result_batches(
         self,
         pool: mp.pool.Pool,
-        args: list[list[tuple[np.ndarray, int, int, np.ndarray, int]]],
+        args: BatchedExtractionArgs,
     ) -> tuple[int, float, list[tuple[int, np.ndarray, int]], list, int]:
         """Calibrate max in-flight batches from the first submitted worker wave.
 
@@ -1198,30 +1198,33 @@ class HDF5CellExtraction(ProcessingStep):
 
         The following optional parameters can also be configured:
 
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | Parameter                            | Default          | Description                                                  |
-        +======================================+==================+==============================================================+
-        | ``normalize_output``                 | ``True``         | Enable percentile normalization of extracted image channels. |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``normalization_range``              | ``(0.001, 0.999)`` | Lower and upper percentiles used for normalization.        |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``compression``                      | ``True``         | Compression mode for the output HDF5 dataset. ``True`` maps |
-        |                                      |                  | to ``lzf``. ``gzip`` and ``False`` are also supported.      |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``target_ram_utilization``           | ``0.85``         | Fraction of total system RAM the extraction job should aim  |
-        |                                      |                  | to stay within when calibrating buffered result batches.    |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``max_inflight_result_batches``      | auto-calibrated  | Explicit override for the number of buffered multiprocessing |
-        |                                      |                  | result batches. If omitted, scPortrait calibrates this from |
-        |                                      |                  | the first worker wave.                                      |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``flush_every``                      | derived from     | Flush cadence for HDF5 output and garbage collection during |
-        |                                      | effective in-    | extraction. If omitted, it is derived from the effective    |
-        |                                      | flight batch     | in-flight batch limit.                                      |
-        |                                      | limit            |                                                              |
-        +--------------------------------------+------------------+--------------------------------------------------------------+
-        | ``max_batch_size``                   | ``1000``         | Upper bound used when building multiprocessing mini-batches.|
-        +--------------------------------------+------------------+--------------------------------------------------------------+
+        .. list-table::
+            :header-rows: 1
+
+            * - Parameter
+              - Default
+              - Description
+            * - ``normalize_output``
+              - ``True``
+              - Enable percentile normalization of extracted image channels.
+            * - ``normalization_range``
+              - ``(0.001, 0.999)``
+              - Lower and upper percentiles used for normalization.
+            * - ``compression``
+              - ``True``
+              - Compression mode for the output HDF5 dataset. ``True`` maps to ``lzf``. ``gzip`` and ``False`` are also supported.
+            * - ``target_ram_utilization``
+              - ``0.85``
+              - Fraction of total system RAM the extraction job should aim to stay within when calibrating buffered result batches.
+            * - ``max_inflight_result_batches``
+              - auto-calibrated
+              - Explicit override for the number of buffered multiprocessing result batches. If omitted, scPortrait calibrates this from the first worker wave.
+            * - ``flush_every``
+              - derived from effective in-flight batch limit
+              - Flush cadence for HDF5 output and garbage collection during extraction. If omitted, it is derived from the effective in-flight batch limit.
+            * - ``max_batch_size``
+              - ``1000``
+              - Upper bound used when building multiprocessing mini-batches.
 
         Normalization settings deserve special attention because they directly
         affect the dynamic range of the extracted single-cell images that are

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -889,17 +889,10 @@ class HDF5CellExtraction(ProcessingStep):
             benchmarking.to_csv(benchmarking_path, index=False)
         self.log("Benchmarking times saved to file.")
 
-    def _get_process_tree_rss_bytes(self) -> int:
-        """Return RSS for the current process and all live child processes."""
-        total_rss = 0
+    def _get_current_process_rss_bytes(self) -> int:
+        """Return RSS for the current process only."""
         process = psutil.Process(os.getpid())
-        processes = [process] + process.children(recursive=True)
-        for proc in processes:
-            try:
-                total_rss += int(proc.memory_info().rss)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                continue
-        return total_rss
+        return int(process.memory_info().rss)
 
     def _estimate_returned_result_bytes(self, results: list[tuple[int, np.ndarray, int]]) -> int:
         """Estimate memory footprint of a returned multiprocessing batch payload."""
@@ -1072,11 +1065,12 @@ class HDF5CellExtraction(ProcessingStep):
     ) -> tuple[int, float, list[tuple[int, np.ndarray, int]], list, int]:
         """Calibrate max in-flight batches from the first submitted worker wave.
 
-        The calibration submits one initial wave of work, observes process-tree
-        RSS while workers are active, and measures the size of the first batch
-        payload returned to the parent process. These measurements are then used
-        to estimate how many outstanding batch results can be buffered while
-        staying within the configured RAM budget for the job.
+        The calibration submits one initial wave of work and measures the size
+        of the first batch payload returned to the parent process. Together
+        with the parent-process RSS observed at that point, these measurements
+        are used to estimate how many outstanding batch results can be buffered
+        in the writer process while staying within the configured RAM budget
+        for the job.
 
         Args:
             pool: Active multiprocessing pool used for extraction.
@@ -1091,7 +1085,6 @@ class HDF5CellExtraction(ProcessingStep):
         self.log("Calibrating max_inflight_result_batches using the first batch of workers...")
         n_total_batches = len(args)
         warmup_submit = min(max(1, int(self.threads)), n_total_batches)
-        baseline_tree_rss = self._get_process_tree_rss_bytes()
 
         pending_results: list = []
         next_submit_ix = 0
@@ -1111,20 +1104,15 @@ class HDF5CellExtraction(ProcessingStep):
                 time.sleep(0.01)
                 continue
 
-            busy_tree_rss = self._get_process_tree_rss_bytes()
             async_result = pending_results.pop(ready_ix)
             first_result = async_result.get()
             first_wait_s = timeit.default_timer() - startup_wait_start
             break
 
         result_batch_bytes = self._estimate_returned_result_bytes(first_result)
-        observed_worker_bytes_total = max(0, busy_tree_rss - baseline_tree_rss - result_batch_bytes)
-        per_worker_bytes = observed_worker_bytes_total / max(1, warmup_submit)
-
         target_job_ram_bytes = self._get_target_job_ram_bytes()
-        current_tree_rss = self._get_process_tree_rss_bytes()
-        reserved_worker_bytes = int(per_worker_bytes * max(1, int(self.threads)))
-        queue_budget_bytes = max(0, target_job_ram_bytes - current_tree_rss - reserved_worker_bytes)
+        current_process_rss = self._get_current_process_rss_bytes()
+        queue_budget_bytes = max(0, target_job_ram_bytes - current_process_rss)
         min_inflight_result_batches = max(1, warmup_submit)
 
         if result_batch_bytes <= 0:
@@ -1147,10 +1135,7 @@ class HDF5CellExtraction(ProcessingStep):
             f"{calibrated_max} (budget_based_n={calibrated_from_budget}, "
             f"worker_floor_n={min_inflight_result_batches}, "
             f"target_job_ram_gb={target_job_ram_bytes / bytes_to_gb:.3f}, "
-            f"total_used_gb={current_tree_rss / bytes_to_gb:.3f}, "
-            f"baseline_tree_rss_gb={baseline_tree_rss / bytes_to_gb:.3f}, "
-            f"busy_tree_rss_gb={busy_tree_rss / bytes_to_gb:.3f}, "
-            f"per_worker_gb={per_worker_bytes / bytes_to_gb:.3f}, "
+            f"parent_rss_gb={current_process_rss / bytes_to_gb:.3f}, "
             f"result_batch_gb={result_batch_bytes / bytes_to_gb:.3f}, "
             f"queue_budget_gb={queue_budget_bytes / bytes_to_gb:.3f})."
         )
@@ -1243,11 +1228,11 @@ class HDF5CellExtraction(ProcessingStep):
 
         In multiprocessing mode, ``max_inflight_result_batches`` is calibrated
         automatically when it is not provided explicitly. The calibration uses
-        the first wave of worker batches to estimate worker memory overhead and
-        returned batch payload size, then chooses an in-flight batch limit that
-        aims to respect ``target_ram_utilization``. If the calculated value
-        would fall below the active worker count, the worker count is used as a
-        minimum and a warning is written to the log.
+        the first wave of worker batches to estimate returned batch payload
+        size together with the parent-process RSS, then chooses an in-flight
+        batch limit that aims to respect ``target_ram_utilization``. If the
+        calculated value would fall below the active worker count, the worker
+        count is used as a minimum and a warning is written to the log.
 
         """
         total_time_start = timeit.default_timer()

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -1195,6 +1195,57 @@ class HDF5CellExtraction(ProcessingStep):
 
                 # directory where intermediate results should be saved
                 cache: "/mnt/temp/cache"
+
+        The following optional parameters can also be configured:
+
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | Parameter                            | Default          | Description                                                  |
+        +======================================+==================+==============================================================+
+        | ``normalize_output``                 | ``True``         | Enable percentile normalization of extracted image channels. |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``normalization_range``              | ``(0.001, 0.999)`` | Lower and upper percentiles used for normalization.        |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``compression``                      | ``True``         | Compression mode for the output HDF5 dataset. ``True`` maps |
+        |                                      |                  | to ``lzf``. ``gzip`` and ``False`` are also supported.      |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``target_ram_utilization``           | ``0.85``         | Fraction of total system RAM the extraction job should aim  |
+        |                                      |                  | to stay within when calibrating buffered result batches.    |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``max_inflight_result_batches``      | auto-calibrated  | Explicit override for the number of buffered multiprocessing |
+        |                                      |                  | result batches. If omitted, scPortrait calibrates this from |
+        |                                      |                  | the first worker wave.                                      |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``flush_every``                      | derived from     | Flush cadence for HDF5 output and garbage collection during |
+        |                                      | effective in-    | extraction. If omitted, it is derived from the effective    |
+        |                                      | flight batch     | in-flight batch limit.                                      |
+        |                                      | limit            |                                                              |
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+        | ``max_batch_size``                   | ``1000``         | Upper bound used when building multiprocessing mini-batches.|
+        +--------------------------------------+------------------+--------------------------------------------------------------+
+
+        Normalization settings deserve special attention because they directly
+        affect the dynamic range of the extracted single-cell images that are
+        stored for downstream analysis. If you are unsure how to choose
+        ``normalize_output`` or ``normalization_range``, refer to the
+        :ref:`single-cell extraction tutorial <single_cell_extraction_tutorial>`
+        for a more detailed walkthrough.
+
+        During extraction, scPortrait can use multiple worker processes to
+        prepare single-cell image batches while the main process writes results
+        to the output HDF5 file. On large datasets with multiple threads, preparing
+        batches can be faster than writing them to disk, which would otherwise
+        allow completed batch results to accumulate in memory. To keep this manageable,
+        the extraction workflow can automatically limit how many completed batch
+        results are allowed to be buffered in memory at the same time.
+
+        In multiprocessing mode, ``max_inflight_result_batches`` is calibrated
+        automatically when it is not provided explicitly. The calibration uses
+        the first wave of worker batches to estimate worker memory overhead and
+        returned batch payload size, then chooses an in-flight batch limit that
+        aims to respect ``target_ram_utilization``. If the calculated value
+        would fall below the active worker count, the worker count is used as a
+        minimum and a warning is written to the log.
+
         """
         total_time_start = timeit.default_timer()
 

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -710,13 +710,13 @@ class HDF5CellExtraction(ProcessingStep):
         """
         with hdf5_lock:
             with h5py.File(self.output_path, "a") as hf:
-                self._single_cell_data_container: h5py.Dataset = hf[self.IMAGE_DATACONTAINER_NAME]
-                self._single_cell_index_container: h5py.Dataset = hf[self.INDEX_DATACONTAINER_NAME]
+                single_cell_data_container: h5py.Dataset = hf[self.IMAGE_DATACONTAINER_NAME]
+                single_cell_index_container: h5py.Dataset = hf[self.INDEX_DATACONTAINER_NAME]
 
                 for res in results:
                     save_index, stack, cell_id = res
-                    self._single_cell_data_container[save_index] = stack
-                    self._single_cell_index_container[save_index] = cell_id
+                    single_cell_data_container[save_index] = stack
+                    single_cell_index_container[save_index] = cell_id
 
     def _initialize_empty_anndata(self) -> None:
         """Initialize an AnnData object to store the extracted single-cell images."""

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -1,8 +1,11 @@
+import gc
 import multiprocessing as mp
 import os
+import pickle
 import platform
 import shutil
 import sys
+import time
 import timeit
 from functools import partial as func_partial
 from pathlib import PosixPath
@@ -11,6 +14,7 @@ import h5py
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import psutil
 import xarray
 from alphabase.io.tempmmap import create_empty_mmap, mmap_array_from_path
 from anndata import AnnData
@@ -87,56 +91,12 @@ class HDF5CellExtraction(ProcessingStep):
         # optional parameters with default values that can be overridden by the values in the config file
 
         ## parameters for image extraction
-        if "normalize_output" in self.config:
-            normalize = self.config["normalize_output"]
-
-            # check that is a valid value
-            assert normalize in [
-                True,
-                False,
-                None,
-                "None",
-            ], "Normalization must be one of the following values [True, False, None, 'None']"
-
-            # convert to boolean
-            if normalize == "None":
-                normalize = False
-            if normalize is None:
-                normalize = False
-
-            self.normalization = normalize
-
-        else:
-            self.normalization = True  # default value
-
-        if "normalization_range" in self.config:
-            normalization_range = self.config["normalization_range"]
-
-            if normalization_range == "None":
-                normalization_range = None
-
-            if normalization_range is not None:
-                assert len(normalization_range) == 2, "Normalization range must be a tuple or list of length 2."
-                assert all(isinstance(x, float | int) and (0 <= x <= 1) for x in normalization_range), (
-                    "Normalization range must be defined as a float between 0 and 1."
-                )
-
-                # conver to tuple to ensure consistency
-                if isinstance(normalization_range, list):
-                    normalization_range = tuple(normalization_range)
-            else:
-                normalization_range = (0.001, 0.999)
-
-            self.normalization_range = normalization_range
-
-        else:
-            self.normalization_range = [0.001, 0.999]
-
-        if not self.normalization:
-            self.normalization_range = ("None", "None")
+        self.normalization = self._get_normalize_output_config()
+        self.normalization_range = self._get_normalization_range_config()
 
         ## parameters for HDF5 file creates
         self.compression = self.config.get("compression", True)
+        self.flush_every = self._get_optional_positive_int_config("flush_every")
 
         ## Deprecated parameters since we no longer directly read from HDF5
         ## Preservering here in case we see better performance by adjusting this behaviour in how we read data from memmapped arrays
@@ -155,6 +115,51 @@ class HDF5CellExtraction(ProcessingStep):
         #     self.hdf5_rdcc_nslots = self.config["hdf5_rdcc_nslots"]
         # else:
         #     self.hdf5_rdcc_nslots = 50000
+
+    def _get_optional_positive_int_config(self, key: str) -> int | None:
+        """Return an optional positive integer config value.
+
+        Args:
+            key: Config entry to validate and read.
+
+        Returns:
+            The configured integer value or ``None`` if the key is absent.
+        """
+        value = self.config.get(key)
+        if value is None:
+            return None
+
+        assert isinstance(value, int) and value >= 1, f"{key} must be an integer >= 1."
+        return value
+
+    def _get_normalize_output_config(self) -> bool:
+        """Resolve normalization enablement from config."""
+        normalize = self.config.get("normalize_output", True)
+        assert normalize in [True, False, None, "None"], (
+            "Normalization must be one of the following values [True, False, None, 'None']"
+        )
+        if normalize in [None, "None"]:
+            return False
+        return bool(normalize)
+
+    def _get_normalization_range_config(self) -> tuple[float, float] | tuple[str, str]:
+        """Resolve normalization percentile range from config."""
+        if not self.normalization:
+            return ("None", "None")
+
+        normalization_range = self.config.get("normalization_range", (0.001, 0.999))
+        if normalization_range == "None" or normalization_range is None:
+            return (0.001, 0.999)
+
+        assert len(normalization_range) == 2, "Normalization range must be a tuple or list of length 2."
+        assert all(isinstance(x, float | int) and (0 <= x <= 1) for x in normalization_range), (
+            "Normalization range must be defined as a float between 0 and 1."
+        )
+
+        if isinstance(normalization_range, list):
+            normalization_range = tuple(normalization_range)
+
+        return normalization_range
 
     def _setup_normalization(self) -> None:
         """Configure normalization of single-cell images based on config.
@@ -510,6 +515,7 @@ class HDF5CellExtraction(ProcessingStep):
         else:
             max_batch_size = max_batch_size
 
+        original_threads = self.threads
         theoretical_max = np.ceil(len(args) / self.threads)
         batch_size = np.int64(min(max_batch_size, theoretical_max))
 
@@ -519,7 +525,7 @@ class HDF5CellExtraction(ProcessingStep):
         # dynamically adjust the number of threads to ensure that we dont initiate more threads than we have arguments
         self.threads = np.int64(min(self.threads, np.ceil(len(args) / self.batch_size)))
 
-        if self.threads != self.threads:
+        if self.threads != original_threads:
             self.log(f"Reducing number of threads to {self.threads} to match number of cell batches to process.")
 
         return [args[i : i + self.batch_size] for i in range(0, len(args), self.batch_size)]
@@ -880,6 +886,276 @@ class HDF5CellExtraction(ProcessingStep):
             benchmarking.to_csv(benchmarking_path, index=False)
         self.log("Benchmarking times saved to file.")
 
+    def _get_process_tree_rss_bytes(self) -> int:
+        """Return RSS for the current process and all live child processes."""
+        total_rss = 0
+        process = psutil.Process(os.getpid())
+        processes = [process] + process.children(recursive=True)
+        for proc in processes:
+            try:
+                total_rss += int(proc.memory_info().rss)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return total_rss
+
+    def _estimate_returned_result_bytes(self, results: list[tuple[int, np.ndarray, int]]) -> int:
+        """Estimate memory footprint of a returned multiprocessing batch payload."""
+        array_bytes = sum(int(stack.nbytes) for _, stack, _ in results)
+        try:
+            serialized_bytes = len(pickle.dumps(results, protocol=pickle.HIGHEST_PROTOCOL))
+        except (pickle.PicklingError, TypeError, AttributeError):
+            serialized_bytes = 0
+        return max(array_bytes, serialized_bytes)
+
+    def _get_target_job_ram_bytes(self) -> int:
+        """Return the configured total RAM budget for this extraction job."""
+        target_utilization = float(self.config.get("target_ram_utilization", 0.85))
+        target_utilization = min(max(target_utilization, 0.1), 0.95)
+        return int(psutil.virtual_memory().total * target_utilization)
+
+    def _get_configured_max_inflight_result_batches(self, n_total_batches: int) -> int | None:
+        """Return explicit in-flight override if present."""
+        if "max_inflight_result_batches" not in self.config:
+            return None
+
+        configured = int(self.config["max_inflight_result_batches"])
+        configured = max(1, min(configured, n_total_batches))
+        self.log(f"Using configured max_inflight_result_batches={configured}.")
+        return configured
+
+    def _resolve_flush_every(self, default_flush_every: int) -> int:
+        """Resolve flush cadence using config override or a supplied default.
+
+        Args:
+            default_flush_every: Fallback flush interval to use when the config
+                does not explicitly set ``flush_every``.
+
+        Returns:
+            Flush interval in processed units.
+        """
+        if self.flush_every is not None:
+            resolved = self.flush_every
+            self.log(f"Using flush_every={resolved}.")
+            return resolved
+
+        resolved = max(1, int(default_flush_every))
+        self.log(f"Using derived flush_every={resolved}.")
+        return resolved
+
+    def _periodic_flush_and_collect(self, counter: int, hf: h5py.File | None, flush_every: int) -> None:
+        """Flush HDF5 output and run garbage collection at a configured interval.
+
+        Args:
+            counter: Number of processed units so far.
+            hf: Open HDF5 file handle to flush if available.
+            flush_every: Number of processed units between flush operations.
+        """
+        if counter % flush_every != 0:
+            return
+
+        if hf is not None:
+            hf.flush()
+        gc.collect()
+
+    def _prepare_extraction_args(self) -> tuple[list, float]:
+        """Generate extraction args and return generation time."""
+        start_arg_generation = timeit.default_timer()
+        self._generate_save_index_lookup(self.classes)
+        args = self._get_arg(self.classes, self.px_centers)
+        time_arg_generation = timeit.default_timer() - start_arg_generation
+        return args, time_arg_generation
+
+    def _load_inputs_to_memmap(self) -> float:
+        """Load segmentation masks and input images into temporary memmaps."""
+        self.log("Loading input images to memory mapped arrays...")
+        start_data_transfer = timeit.default_timer()
+
+        self.path_seg_masks = self.filehandler._load_seg_to_memmap(
+            seg_name=self.masks, tmp_dir_abs_path=self._tmp_dir_path
+        )
+        self.path_image_data = self.filehandler._load_input_image_to_memmap(tmp_dir_abs_path=self._tmp_dir_path)
+
+        time_data_transfer = timeit.default_timer() - start_data_transfer
+        if self.debug:
+            self.log(
+                f"Finished transferring data to memory mapped arrays. Time taken: {time_data_transfer:.2f} seconds."
+            )
+        return time_data_transfer
+
+    def _finish_processed_batch(
+        self,
+        processed_count: int,
+        flush_every: int,
+        pbar: tqdm | None = None,
+        hf: h5py.File | None = None,
+    ) -> int:
+        """Apply common bookkeeping after a cell or batch has been written."""
+        processed_count += 1
+        self._periodic_flush_and_collect(counter=processed_count, hf=hf, flush_every=flush_every)
+        if pbar is not None:
+            pbar.update(1)
+        return processed_count
+
+    def _iter_completed_batch_results(
+        self,
+        pool: mp.pool.Pool,
+        args: list[list[tuple[np.ndarray, int, int, np.ndarray, int]]],
+        max_inflight_result_batches: int,
+        pending_results: list | None = None,
+        next_submit_ix: int = 0,
+    ):
+        """Yield completed multiprocessing batch results while bounding in-flight tasks.
+
+        This helper exists to keep the extraction pipeline from submitting an
+        unbounded number of batch jobs whose results then accumulate in memory
+        faster than the main process can write them to disk. Each completed
+        worker task returns a batch of extracted single-cell image stacks,
+        which can be large. If too many completed batches are allowed to remain
+        outstanding at once, resident memory can grow steadily until the job
+        runs out of memory.
+
+        To avoid that, this helper keeps at most
+        ``max_inflight_result_batches`` tasks submitted but not yet consumed.
+        As soon as one completed batch is yielded back to the caller, the
+        helper submits the next pending batch task, maintaining a bounded
+        producer/consumer pipeline. This preserves multiprocessing throughput
+        while placing an upper bound on the amount of result data that can be
+        buffered in flight at one time.
+
+        Args:
+            pool: Active multiprocessing pool used for extraction.
+            args: Batched extraction arguments to submit.
+            max_inflight_result_batches: Maximum number of submitted but not yet
+                consumed batch tasks.
+
+        Yields:
+            Completed batch extraction results as returned by
+            ``_extract_classes_multi``.
+        """
+        pending_results = [] if pending_results is None else pending_results
+        n_total_batches = len(args)
+
+        while (
+            len(pending_results) < min(max_inflight_result_batches, n_total_batches)
+            and next_submit_ix < n_total_batches
+        ):
+            pending_results.append(pool.apply_async(self._extract_classes_multi, (args[next_submit_ix],)))
+            next_submit_ix += 1
+
+        while pending_results:
+            ready_ix = None
+            for i, async_result in enumerate(pending_results):
+                if async_result.ready():
+                    ready_ix = i
+                    break
+
+            if ready_ix is None:
+                time.sleep(0.01)
+                continue
+
+            async_result = pending_results.pop(ready_ix)
+            result = async_result.get()
+
+            while (
+                len(pending_results) < min(max_inflight_result_batches, n_total_batches)
+                and next_submit_ix < n_total_batches
+            ):
+                pending_results.append(pool.apply_async(self._extract_classes_multi, (args[next_submit_ix],)))
+                next_submit_ix += 1
+
+            yield result
+
+    def _calibrate_max_inflight_result_batches(
+        self,
+        pool: mp.pool.Pool,
+        args: list[list[tuple[np.ndarray, int, int, np.ndarray, int]]],
+    ) -> tuple[int, float, list[tuple[int, np.ndarray, int]], list, int]:
+        """Calibrate max in-flight batches from the first submitted worker wave.
+
+        The calibration submits one initial wave of work, observes process-tree
+        RSS while workers are active, and measures the size of the first batch
+        payload returned to the parent process. These measurements are then used
+        to estimate how many outstanding batch results can be buffered while
+        staying within the configured RAM budget for the job.
+
+        Args:
+            pool: Active multiprocessing pool used for extraction.
+            args: Batched extraction arguments to submit.
+
+        Returns:
+            Tuple containing the calibrated max in-flight batch count, the time
+            until the first batch completed, the first completed result itself,
+            the remaining pending async results, and the next argument index to
+            submit.
+        """
+        self.log("Calibrating max_inflight_result_batches using the first batch of workers...")
+        n_total_batches = len(args)
+        warmup_submit = min(max(1, int(self.threads)), n_total_batches)
+        baseline_tree_rss = self._get_process_tree_rss_bytes()
+
+        pending_results: list = []
+        next_submit_ix = 0
+        while len(pending_results) < warmup_submit and next_submit_ix < n_total_batches:
+            pending_results.append(pool.apply_async(self._extract_classes_multi, (args[next_submit_ix],)))
+            next_submit_ix += 1
+
+        startup_wait_start = timeit.default_timer()
+        while True:
+            ready_ix = None
+            for i, async_result in enumerate(pending_results):
+                if async_result.ready():
+                    ready_ix = i
+                    break
+
+            if ready_ix is None:
+                time.sleep(0.01)
+                continue
+
+            busy_tree_rss = self._get_process_tree_rss_bytes()
+            async_result = pending_results.pop(ready_ix)
+            first_result = async_result.get()
+            first_wait_s = timeit.default_timer() - startup_wait_start
+            break
+
+        result_batch_bytes = self._estimate_returned_result_bytes(first_result)
+        observed_worker_bytes_total = max(0, busy_tree_rss - baseline_tree_rss - result_batch_bytes)
+        per_worker_bytes = observed_worker_bytes_total / max(1, warmup_submit)
+
+        target_job_ram_bytes = self._get_target_job_ram_bytes()
+        current_tree_rss = self._get_process_tree_rss_bytes()
+        reserved_worker_bytes = int(per_worker_bytes * max(1, int(self.threads)))
+        queue_budget_bytes = max(0, target_job_ram_bytes - current_tree_rss - reserved_worker_bytes)
+        min_inflight_result_batches = max(1, warmup_submit)
+
+        if result_batch_bytes <= 0:
+            calibrated_from_budget = min_inflight_result_batches
+        else:
+            calibrated_from_budget = max(1, min(int(queue_budget_bytes // result_batch_bytes), n_total_batches))
+
+        if calibrated_from_budget < min_inflight_result_batches:
+            self.log(
+                "Warning: target RAM budget would limit max_inflight_result_batches to "
+                f"{calibrated_from_budget}, below the active worker floor of {min_inflight_result_batches}. "
+                "Using the worker-count floor instead. If stricter memory limiting is required, reduce `threads`."
+            )
+
+        calibrated_max = max(min_inflight_result_batches, calibrated_from_budget)
+
+        bytes_to_gb = 1024**3
+        self.log(
+            "Calibrated max_inflight_result_batches="
+            f"{calibrated_max} (budget_based_n={calibrated_from_budget}, "
+            f"worker_floor_n={min_inflight_result_batches}, "
+            f"target_job_ram_gb={target_job_ram_bytes / bytes_to_gb:.3f}, "
+            f"total_used_gb={current_tree_rss / bytes_to_gb:.3f}, "
+            f"baseline_tree_rss_gb={baseline_tree_rss / bytes_to_gb:.3f}, "
+            f"busy_tree_rss_gb={busy_tree_rss / bytes_to_gb:.3f}, "
+            f"per_worker_gb={per_worker_bytes / bytes_to_gb:.3f}, "
+            f"result_batch_gb={result_batch_bytes / bytes_to_gb:.3f}, "
+            f"queue_budget_gb={queue_budget_bytes / bytes_to_gb:.3f})."
+        )
+        return calibrated_max, first_wait_s, first_result, pending_results, next_submit_ix
+
     def process(
         self, partial: bool = False, n_cells: int = None, seed: int = 42, output_folder_name: str | None = None
     ) -> None:
@@ -945,37 +1221,16 @@ class HDF5CellExtraction(ProcessingStep):
         else:
             self.log(f"Starting single-cell image extraction of {self.num_classes} cells...")
 
-        # generate cell pairings to extract
-        start_arg_generation = timeit.default_timer()
-
-        self._generate_save_index_lookup(self.classes)
-        args = self._get_arg(self.classes, self.px_centers)
-        stop_arg_generation = timeit.default_timer()
-        time_arg_generation = stop_arg_generation - start_arg_generation
-
-        # convert input images to memory mapped temp arrays for faster reading
-        self.log("Loading input images to memory mapped arrays...")
-        start_data_transfer = timeit.default_timer()
-
-        self.path_seg_masks = self.filehandler._load_seg_to_memmap(
-            seg_name=self.masks, tmp_dir_abs_path=self._tmp_dir_path
-        )
-        self.path_image_data = self.filehandler._load_input_image_to_memmap(tmp_dir_abs_path=self._tmp_dir_path)
-
-        stop_data_transfer = timeit.default_timer()
-        time_data_transfer = stop_data_transfer - start_data_transfer
-
-        if self.debug:
-            self.log(
-                f"Finished transferring data to memory mapped arrays. Time taken: {time_data_transfer:.2f} seconds."
-            )
+        args, time_arg_generation = self._prepare_extraction_args()
+        time_data_transfer = self._load_inputs_to_memmap()
 
         # actually perform single-cell image extraction
         start_extraction = timeit.default_timer()
-
         if self.threads <= 1:
             # set up for single-threaded processing
             self._setup_normalization()
+            single_thread_flush_default = max(1, int(self.config.get("max_batch_size", 1000)))
+            flush_every = self._resolve_flush_every(single_thread_flush_default)
 
             self.seg_masks = mmap_array_from_path(self.path_seg_masks)
             self.image_data = mmap_array_from_path(self.path_image_data)
@@ -989,10 +1244,17 @@ class HDF5CellExtraction(ProcessingStep):
                 self._single_cell_index_container = hf[self.INDEX_DATACONTAINER_NAME]
 
                 self.log("Running in single threaded mode.")
+                processed_cells = 0
                 for arg in tqdm(args, total=len(args), desc="Extracting cell batches"):
                     self._extract_classes(arg)
+                    processed_cells = self._finish_processed_batch(
+                        processed_count=processed_cells,
+                        flush_every=flush_every,
+                        hf=hf,
+                    )
         else:
             args = self._generate_batched_args(args)
+            n_total_batches = len(args)
 
             self.log(f"Running in multiprocessing mode with {self.threads} threads.")
 
@@ -1003,26 +1265,55 @@ class HDF5CellExtraction(ProcessingStep):
                 with mp.get_context("fork").Pool(
                     processes=self.threads
                 ) as pool:  # both spawn and fork work but fork is faster so forcing fork here
-                    iterator = pool.imap_unordered(self._extract_classes_multi, args)
-                    if len(args) > 0:
+                    if n_total_batches > 0:
                         self.log("Workers initialized. Waiting for first completed extraction batch...")
-                        wait_start = timeit.default_timer()
-                        first_result = next(iterator)
-                        first_wait_s = timeit.default_timer() - wait_start
+                        configured_max_inflight = self._get_configured_max_inflight_result_batches(n_total_batches)
+                        if configured_max_inflight is not None:
+                            startup_wait_start = timeit.default_timer()
+                            result_iterator = self._iter_completed_batch_results(
+                                pool=pool,
+                                args=args,
+                                max_inflight_result_batches=configured_max_inflight,
+                            )
+                            first_result = next(result_iterator)
+                            first_wait_s = timeit.default_timer() - startup_wait_start
+                            max_inflight_result_batches = configured_max_inflight
+                        else:
+                            (
+                                max_inflight_result_batches,
+                                first_wait_s,
+                                first_result,
+                                pending_results,
+                                next_submit_ix,
+                            ) = self._calibrate_max_inflight_result_batches(pool=pool, args=args)
+                            result_iterator = self._iter_completed_batch_results(
+                                pool=pool,
+                                args=args,
+                                max_inflight_result_batches=max_inflight_result_batches,
+                                pending_results=pending_results,
+                                next_submit_ix=next_submit_ix,
+                            )
+
+                        flush_every = self._resolve_flush_every(max_inflight_result_batches)
+                        self.log(f"Limiting in-flight result batches to {max_inflight_result_batches}.")
                         self.log(f"First batch received after {first_wait_s:.2f} seconds.")
+                        processed_batches = 0
 
-                        write_start = timeit.default_timer()
-                        self._write_to_hdf5(first_result, lock)
-                        first_write_s = timeit.default_timer() - write_start
-                        self.log(f"First batch written to HDF5 in {first_write_s:.2f} seconds.")
+                        with tqdm(total=n_total_batches, desc="Extracting cell batches") as pbar:
+                            self._write_to_hdf5(first_result, lock)
+                            processed_batches = self._finish_processed_batch(
+                                processed_count=processed_batches,
+                                flush_every=flush_every,
+                                pbar=pbar,
+                            )
 
-                        with tqdm(total=len(args), initial=1, desc="Extracting cell batches") as pbar:
-                            for _ in range(len(args) - 1):
-                                result = next(iterator)
-
+                            for result in result_iterator:
                                 self._write_to_hdf5(result, lock)
-
-                                pbar.update(1)
+                                processed_batches = self._finish_processed_batch(
+                                    processed_count=processed_batches,
+                                    flush_every=flush_every,
+                                    pbar=pbar,
+                                )
                     pool.close()
                     pool.join()
 

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -136,10 +136,7 @@ class HDF5CellExtraction(ProcessingStep):
             self.normalization_range = ("None", "None")
 
         ## parameters for HDF5 file creates
-        if "compression" in self.config:
-            self.compression = self.config["compression"]
-        else:
-            self.compression = True
+        self.compression = self.config.get("compression", True)
 
         ## Deprecated parameters since we no longer directly read from HDF5
         ## Preservering here in case we see better performance by adjusting this behaviour in how we read data from memmapped arrays
@@ -204,21 +201,13 @@ class HDF5CellExtraction(ProcessingStep):
         if not os.path.isdir(self.extraction_data_directory):
             os.makedirs(self.extraction_data_directory)
             self.log(f"Created new directory for extraction results: {self.extraction_data_directory}")
+        elif self.overwrite_run_path:
+            self.log(f"Output folder at {self.extraction_data_directory} already exists. Overwriting...")
+            shutil.rmtree(self.extraction_data_directory)
+            os.makedirs(self.extraction_data_directory)
+            self.log(f"Created new directory for extraction results: {self.extraction_data_directory}")
         else:
-            if self.overwrite_run_path:
-                self.log(f"Output folder at {self.extraction_data_directory} already exists. Overwriting...")
-                shutil.rmtree(self.extraction_data_directory)
-                os.makedirs(self.extraction_data_directory)
-                self.log(f"Created new directory for extraction results: {self.extraction_data_directory}")
-
-            elif self.overwrite_run_path:
-                self.log(f"Output folder at {self.extraction_data_directory} already exists. Overwriting...")
-                shutil.rmtree(self.extraction_data_directory)
-                os.makedirs(self.extraction_data_directory)
-                self.log(f"Created new directory for extraction results: {self.extraction_data_directory}")
-
-            else:
-                raise ValueError("Output folder already exists. Set overwrite_run_path to True to overwrite.")
+            raise ValueError("Output folder already exists. Set overwrite_run_path to True to overwrite.")
 
         self.log(f"Setup output folder at {self.extraction_data_directory}")
 
@@ -712,9 +701,7 @@ class HDF5CellExtraction(ProcessingStep):
             with h5py.File(self.output_path, "a") as hf:
                 single_cell_data_container: h5py.Dataset = hf[self.IMAGE_DATACONTAINER_NAME]
                 single_cell_index_container: h5py.Dataset = hf[self.INDEX_DATACONTAINER_NAME]
-
-                for res in results:
-                    save_index, stack, cell_id = res
+                for save_index, stack, cell_id in results:
                     single_cell_data_container[save_index] = stack
                     single_cell_index_container[save_index] = cell_id
 

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -600,7 +600,8 @@ class Project(Logable):
 
     def view_sdata(self):
         """Start an interactive napari viewer to look at the sdata object associated with the project.
-        Note:
+
+        .. note::
             This only works in sessions with a visual interface.
         """
         # open interactive viewer in napari

--- a/tests/unit_tests/pipeline/test_extraction_memory_calibration.py
+++ b/tests/unit_tests/pipeline/test_extraction_memory_calibration.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from scportrait.pipeline.extraction import HDF5CellExtraction
+
+
+def _make_extraction(tmp_path, config: dict | None = None) -> HDF5CellExtraction:
+    base_config = {
+        "threads": 4,
+        "image_size": 128,
+        "cache": str(tmp_path / "cache"),
+    }
+    if config is not None:
+        base_config.update(config)
+    return HDF5CellExtraction(config=base_config, directory=tmp_path / "extraction")
+
+
+def test_get_configured_max_inflight_result_batches_uses_override(tmp_path):
+    extraction = _make_extraction(tmp_path, {"max_inflight_result_batches": 50})
+
+    configured = extraction._get_configured_max_inflight_result_batches(n_total_batches=12)
+
+    assert configured == 12
+
+
+def test_calibrate_max_inflight_result_batches_enforces_worker_floor_and_logs_warning(tmp_path, monkeypatch):
+    extraction = _make_extraction(tmp_path, {"target_ram_utilization": 0.3})
+    extraction.threads = 4
+
+    # Synthetic first returned batch
+    result = [(0, np.zeros((3, 8, 8), dtype=np.float32), 101)]
+
+    class FakeAsyncResult:
+        def __init__(self, value):
+            self._value = value
+
+        def ready(self):
+            return True
+
+        def get(self):
+            return self._value
+
+    class FakePool:
+        def apply_async(self, func, call_args):
+            return FakeAsyncResult(result)
+
+    pool = FakePool()
+    args = [[(0, 0, 101, (10.0, 10.0))] for _ in range(6)]
+
+    rss_values = iter(
+        [
+            4 * 1024**3,  # baseline_tree_rss
+            20 * 1024**3,  # busy_tree_rss
+            20 * 1024**3,  # current_tree_rss
+        ]
+    )
+    monkeypatch.setattr(extraction, "_get_process_tree_rss_bytes", lambda: next(rss_values))
+    monkeypatch.setattr(extraction, "_get_target_job_ram_bytes", lambda: int(12.8 * 1024**3))
+
+    log_messages: list[str] = []
+    monkeypatch.setattr(extraction, "log", log_messages.append)
+
+    calibrated_max, _, first_result, pending_results, next_submit_ix = (
+        extraction._calibrate_max_inflight_result_batches(
+            pool=pool,
+            args=args,
+        )
+    )
+
+    assert calibrated_max == 4
+    assert first_result == result
+    assert len(pending_results) == 3
+    assert next_submit_ix == 4
+    assert any("Warning: target RAM budget would limit max_inflight_result_batches" in msg for msg in log_messages)
+    assert any("worker_floor_n=4" in msg for msg in log_messages)

--- a/tests/unit_tests/pipeline/test_extraction_memory_calibration.py
+++ b/tests/unit_tests/pipeline/test_extraction_memory_calibration.py
@@ -50,14 +50,7 @@ def test_calibrate_max_inflight_result_batches_enforces_worker_floor_and_logs_wa
     pool = FakePool()
     args = [[(0, 0, 101, (10.0, 10.0))] for _ in range(6)]
 
-    rss_values = iter(
-        [
-            4 * 1024**3,  # baseline_tree_rss
-            20 * 1024**3,  # busy_tree_rss
-            20 * 1024**3,  # current_tree_rss
-        ]
-    )
-    monkeypatch.setattr(extraction, "_get_process_tree_rss_bytes", lambda: next(rss_values))
+    monkeypatch.setattr(extraction, "_get_current_process_rss_bytes", lambda: int(20 * 1024**3))
     monkeypatch.setattr(extraction, "_get_target_job_ram_bytes", lambda: int(12.8 * 1024**3))
 
     log_messages: list[str] = []
@@ -76,3 +69,4 @@ def test_calibrate_max_inflight_result_batches_enforces_worker_floor_and_logs_wa
     assert next_submit_ix == 4
     assert any("Warning: target RAM budget would limit max_inflight_result_batches" in msg for msg in log_messages)
     assert any("worker_floor_n=4" in msg for msg in log_messages)
+    assert any("parent_rss_gb=" in msg for msg in log_messages)


### PR DESCRIPTION
reported by @vvarlamova 

- implemented automatic flushing and gc.collection after N batches to clean up caches
- capped the maximum number of inflight results kept (i.e. computed results that have not yet been written to disk)