### PR TITLE
Fix Windows config-path handling in ProcessingStep

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -190,6 +190,37 @@ to integrate the changes into yours.
 
 While the [pre-commit.ci][] is useful, we strongly encourage installing and running pre-commit locally first to understand its usage.
 
+### Path handling
+
+For filesystem APIs, prefer accepting `str | os.PathLike[str]`.
+
+- Use `os.PathLike[str]` in type hints, but use unparameterized `os.PathLike` in `isinstance(...)` checks at runtime.
+- If a function only passes the path through to `open`, `os.path`, `h5py`, or similar libraries, keep the input typed as `str | os.PathLike[str]`.
+- If a function needs path methods such as `.parent`, `.suffix`, or `.name`, normalize first with `Path(...)` inside the function.
+- Reuse the shared helpers in `scportrait._utils.paths` instead of re-implementing local path helpers.
+- Use `normalize_path(...)` when you need a concrete `Path` for internal path operations.
+- Use `path_suffix(...)` when you need a normalized suffix without the leading dot.
+- additional helpers can be added to `scportrait._utils.paths` as needed, but try to avoid adding new dependencies (e.g., `pathlib2`) for simple path operations.
+
+Example:
+
+```python
+from os import PathLike
+
+from scportrait._utils.paths import normalize_path, path_suffix
+
+def read_config(path: str | PathLike[str]) -> dict:
+    with open(path) as stream:
+        ...
+
+def get_output_dir(path: str | PathLike[str]):
+    normalized = normalize_path(path)
+    return normalized.parent
+
+def is_hdf5(path: str | PathLike[str]) -> bool:
+    return path_suffix(path) in {"h5", "hdf5"}
+```
+
 ## Writing documentation
 
 Please write documentation for new or changed features and use-cases. This project uses [sphinx][] with the following features:

--- a/src/scportrait/_utils/__init__.py
+++ b/src/scportrait/_utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for scPortrait."""
 
 from .deprecation import deprecated
+from .paths import normalize_path, path_suffix
 
-__all__ = ["deprecated"]
+__all__ = ["deprecated", "normalize_path", "path_suffix"]

--- a/src/scportrait/_utils/paths.py
+++ b/src/scportrait/_utils/paths.py
@@ -1,0 +1,12 @@
+import os
+from pathlib import Path
+
+
+def normalize_path(path: str | os.PathLike[str]) -> Path:
+    """Return a concrete ``Path`` for internal path operations."""
+    return Path(path)
+
+
+def path_suffix(path: str | os.PathLike[str]) -> str:
+    """Return a normalized suffix without the leading dot."""
+    return normalize_path(path).suffix.lstrip(".")

--- a/src/scportrait/pipeline/_base.py
+++ b/src/scportrait/pipeline/_base.py
@@ -7,7 +7,6 @@ import shutil
 import tempfile
 import warnings
 from datetime import datetime
-from pathlib import PosixPath
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -234,9 +233,9 @@ class ProcessingStep(Logable):
 
     def __init__(
         self,
-        config: str | PosixPath | dict[str, Any],
-        directory: str | PosixPath = None,
-        project_location: str | PosixPath = None,
+        config: str | os.PathLike[str] | dict[str, Any],
+        directory: str | os.PathLike[str] = None,
+        project_location: str | os.PathLike[str] = None,
         debug: bool = False,
         overwrite: bool = False,
         project: Project | None = None,
@@ -275,7 +274,7 @@ class ProcessingStep(Logable):
             self.filehandler = None
 
         raw_config: dict[str, Any]
-        if isinstance(config, str | PosixPath):
+        if isinstance(config, (str, os.PathLike)):
             raw_config = read_config(config)
         else:
             raw_config = config

--- a/src/scportrait/pipeline/_utils/helper.py
+++ b/src/scportrait/pipeline/_utils/helper.py
@@ -1,4 +1,4 @@
-from pathlib import PosixPath
+import os
 from typing import TypeVar
 
 import yaml
@@ -6,7 +6,7 @@ import yaml
 T = TypeVar("T")
 
 
-def read_config(config_path: str | PosixPath) -> dict:
+def read_config(config_path: str | os.PathLike[str]) -> dict:
     with open(config_path) as stream:
         try:
             config = yaml.safe_load(stream)
@@ -23,7 +23,7 @@ class QuotedStringDumper(yaml.SafeDumper):
 QuotedStringDumper.add_representer(str, QuotedStringDumper.represent_str)
 
 
-def write_config(config: dict, config_path: str | PosixPath) -> None:
+def write_config(config: dict, config_path: str | os.PathLike[str]) -> None:
     with open(config_path, "w") as stream:
         try:
             yaml.dump(config, stream, sort_keys=False, Dumper=QuotedStringDumper)

--- a/src/scportrait/pipeline/extraction.py
+++ b/src/scportrait/pipeline/extraction.py
@@ -7,7 +7,6 @@ import sys
 import time
 import timeit
 from functools import partial as func_partial
-from pathlib import PosixPath
 from typing import TypeAlias
 
 import h5py
@@ -192,7 +191,7 @@ class HDF5CellExtraction(ProcessingStep):
 
             self.norm_function = min_max
 
-    def _get_output_path(self) -> str | PosixPath:
+    def _get_output_path(self) -> str | os.PathLike[str]:
         """Get the output path for the extraction results."""
         return self.extraction_data_directory
 

--- a/src/scportrait/pipeline/featurization.py
+++ b/src/scportrait/pipeline/featurization.py
@@ -7,7 +7,6 @@ import shutil
 import warnings
 from contextlib import redirect_stdout
 from functools import partial as func_partial
-from pathlib import PosixPath
 from typing import TYPE_CHECKING
 
 import h5py
@@ -157,7 +156,7 @@ class _FeaturizationBase(ProcessingStep):
         """Extract relevant metadata from single-cell image file(s).
         Will ensure that metadata that must be consistent across files is consistent.
         """
-        if isinstance(self.extraction_file, str | PosixPath):
+        if isinstance(self.extraction_file, (str, os.PathLike)):
             with h5py.File(self.extraction_file, "r") as f:
                 metadata: h5py.Dataset = f["uns"][self.DEFAULT_NAME_SINGLE_CELL_IMAGES]
                 self.n_masks = metadata["n_masks"][()]
@@ -786,7 +785,7 @@ class _FeaturizationBase(ProcessingStep):
         else:
             return None
 
-    def _write_results_csv(self, results: pd.DataFrame, path: str | PosixPath) -> None:
+    def _write_results_csv(self, results: pd.DataFrame, path: str | os.PathLike[str]) -> None:
         """Write results to a CSV file."""
         results.to_csv(path, index=False)
         self.log(f"Results saved to file: {path}")

--- a/src/scportrait/pipeline/featurization.py
+++ b/src/scportrait/pipeline/featurization.py
@@ -24,7 +24,7 @@ from scportrait.tools.ml.datasets import H5ScSingleCellDataset
 from scportrait.tools.ml.plmodels import MultilabelSupervisedModel
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from dask.dataframe.core import DataFrame as da_DataFrame
 
@@ -313,7 +313,11 @@ class _FeaturizationBase(ProcessingStep):
             self.inference_device = self._detect_automatic_inference_device()
             self.log(f"Automatically configured inference device to {self.inference_device}")
 
-    def _general_setup(self, dataset_paths: str | list[str], return_results: bool = False) -> None:
+    def _general_setup(
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        return_results: bool = False,
+    ) -> None:
         """Helper function to execute all setup functions that are common to all featurization steps.
 
         Args:
@@ -544,7 +548,7 @@ class _FeaturizationBase(ProcessingStep):
 
     def generate_dataloader(
         self,
-        dataset_paths: str | list[str],
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
         dataset_labels: int | list[int] = 0,
         selected_transforms: transforms.Compose = transforms.Compose([]),
         size: int = 0,
@@ -575,18 +579,17 @@ class _FeaturizationBase(ProcessingStep):
             self.log(f"Expected image size is set to {self.expected_imagesize}. Resizing images to this size.")
             t = transforms.Compose([t, transforms.Resize(self.expected_imagesize)])
 
-        if isinstance(dataset_paths, list):
-            assert isinstance(dataset_labels, list), (
-                "If multiple directories are provided, multiple labels must be provided."
-            )
-            paths = dataset_paths
-            dataset_labels = dataset_labels
-        elif isinstance(dataset_paths, str):
+        if isinstance(dataset_paths, (str, os.PathLike)):
             assert isinstance(dataset_labels, int), (
                 "If only one directory is provided, only one label must be provided."
             )
             paths = [dataset_paths]
             dataset_labels = [dataset_labels]
+        else:
+            assert isinstance(dataset_labels, list), (
+                "If multiple directories are provided, multiple labels must be provided."
+            )
+            paths = list(dataset_paths)
 
         f = io.StringIO()
         with redirect_stdout(f):
@@ -1006,7 +1009,11 @@ class MLClusterClassifier(_FeaturizationBase):
         else:
             self.transforms = transforms.Compose([])  # default is no transforms
 
-    def _setup(self, dataset_paths: str | list[str], return_results: bool) -> None:
+    def _setup(
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        return_results: bool,
+    ) -> None:
         self._general_setup(dataset_paths=dataset_paths, return_results=return_results)
         self._get_model_specs()
         self._get_network_dir()
@@ -1028,7 +1035,7 @@ class MLClusterClassifier(_FeaturizationBase):
 
     def process(
         self,
-        dataset_paths: str | list[str],
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
         dataset_labels: int | list[int] = 0,
         size: int = 0,
         return_results: bool = False,
@@ -1179,7 +1186,7 @@ class EnsembleClassifier(_FeaturizationBase):
         memory_usage = self._get_gpu_memory_usage()
         self.log(f"GPU memory usage after loading models: {memory_usage}")
 
-    def _setup(self, dataset_paths: str, return_results: bool):
+    def _setup(self, dataset_paths: str | os.PathLike[str], return_results: bool):
         self._general_setup(dataset_paths=dataset_paths, return_results=return_results)
         self._get_model_specs()
         self._setup_transforms()
@@ -1194,7 +1201,11 @@ class EnsembleClassifier(_FeaturizationBase):
         self.create_temp_dir()
 
     def process(
-        self, dataset_paths: str, dataset_labels: int | list[int] = 0, size: int = 0, return_results: bool = False
+        self,
+        dataset_paths: str | os.PathLike[str],
+        dataset_labels: int | list[int] = 0,
+        size: int = 0,
+        return_results: bool = False,
     ) -> None | dict:
         """
         Args:
@@ -1392,7 +1403,11 @@ class ConvNeXtFeaturizer(_FeaturizationBase):
         column_names = [f"convnext_feature_{i}" for i in range(N_CONVNEXT_FEATURES)]
         return column_names
 
-    def _setup(self, dataset_paths: str | list[str], return_results: bool) -> None:
+    def _setup(
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        return_results: bool,
+    ) -> None:
         self._silence_warnings()
         self._general_setup(dataset_paths=dataset_paths, return_results=return_results)
         self._load_model()
@@ -1402,7 +1417,7 @@ class ConvNeXtFeaturizer(_FeaturizationBase):
 
     def process(
         self,
-        dataset_paths: str | list[str],
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
         dataset_labels: int | list[int] = 0,
         size: int = 0,
         return_results: bool = False,
@@ -1642,7 +1657,11 @@ class CellFeaturizer(_cellFeaturizerBase):
 
         self.channel_selection = None  # ensure that all images are passed to the function
 
-    def _setup(self, dataset_paths: str | list[str], return_results: bool):
+    def _setup(
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        return_results: bool,
+    ):
         self._general_setup(dataset_paths=dataset_paths, return_results=return_results)
         self._setup_transforms()
         self._get_single_cell_datafile_specs()
@@ -1650,7 +1669,7 @@ class CellFeaturizer(_cellFeaturizerBase):
 
     def process(
         self,
-        dataset_paths: str | list[str],
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
         dataset_labels: int | list[int] = 0,
         size: int = 0,
         return_results: bool = False,
@@ -1767,7 +1786,11 @@ class CellFeaturizer_single_channel(_cellFeaturizerBase):
             self.channel_selection = [0, self.channel_selection]
         return
 
-    def _setup(self, dataset_paths: str | list[str], return_results: bool):
+    def _setup(
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        return_results: bool,
+    ):
         self._general_setup(dataset_paths=dataset_paths, return_results=return_results)
         self._setup_channel_selection()
         self._setup_transforms()
@@ -1775,7 +1798,11 @@ class CellFeaturizer_single_channel(_cellFeaturizerBase):
         self.create_temp_dir()
 
     def process(
-        self, dataset_paths: str | list[str], dataset_labels: int | list[int] = 0, size=0, return_results: bool = False
+        self,
+        dataset_paths: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+        dataset_labels: int | list[int] = 0,
+        size=0,
+        return_results: bool = False,
     ) -> None | pd.DataFrame:
         """
         Args:

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -149,8 +149,8 @@ class Project(Logable):
 
     def __init__(
         self,
-        project_location: str,
-        config_path: str = None,
+        project_location: str | os.PathLike[str],
+        config_path: str | os.PathLike[str] | None = None,
         segmentation_f=None,
         extraction_f=None,
         featurization_f=None,
@@ -160,8 +160,8 @@ class Project(Logable):
     ):
         """
         Args:
-            project_location (str): Path to the project directory.
-            config_path (str): Path to the config file.
+            project_location (str | os.PathLike[str]): Path to the project directory.
+            config_path (str | os.PathLike[str]): Path to the config file.
             segmentation_f (optional): Segmentation method to be used for the project.
             extraction_f (optional): Extraction method to be used for the project.
             featurization_f (optional): Featurization method to be used for the project.
@@ -253,12 +253,12 @@ class Project(Logable):
 
     ##### Setup Functions #####
 
-    def _load_config_from_file(self, file_path):
+    def _load_config_from_file(self, file_path: str | os.PathLike[str]) -> None:
         """
         Loads config from file and writes it to self.config
 
         Args:
-            file_path (str): Path to the config.yml file that should be loaded.
+            file_path (str | os.PathLike[str]): Path to the config.yml file that should be loaded.
         """
         self.log(f"Loading config from {file_path}")
 
@@ -271,11 +271,11 @@ class Project(Logable):
         self.config = config_dict
         write_config(self.config, os.path.join(self.project_location, self.DEFAULT_CONFIG_NAME))
 
-    def _get_config_file(self, config_path: str | None = None) -> None:
+    def _get_config_file(self, config_path: str | os.PathLike[str] | None = None) -> None:
         """Load the config file for the project. If no config file is passed the default config file in the project directory is loaded.
 
         Args:
-            config_path (str, optional): Path to the config file. Default is ``None``.
+            config_path (str | os.PathLike[str], optional): Path to the config file. Default is ``None``.
 
         Returns:
             None: the config dictionary project.config is updated.

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -82,11 +82,11 @@ class Project(Logable):
     Extraction Methods should be based on :func:`HDF5CellExtraction <scportrait.pipeline.extraction.HDF5CellExtraction>`.
 
     Attributes:
-        config (dict): Dictionary containing the config file.
-        nuc_seg_name (str): Name of the nucleus segmentation object.
-        cyto_seg_name (str): Name of the cytosol segmentation object.
-        sdata_path (str): Path to the spatialdata object.
-        filehander (sdata_filehandler): Filehandler for the spatialdata object which manages all calls or updates to the spatialdata object.
+        config: Dictionary containing the config file.
+        nuc_seg_name: Name of the nucleus segmentation object.
+        cyto_seg_name: Name of the cytosol segmentation object.
+        sdata_path: Path to the spatialdata object.
+        filehander: Filehandler for the spatialdata object which manages all calls or updates to the spatialdata object.
     """
 
     # define cleanup behaviour
@@ -160,14 +160,14 @@ class Project(Logable):
     ):
         """
         Args:
-            project_location (str | os.PathLike[str]): Path to the project directory.
-            config_path (str | os.PathLike[str]): Path to the config file.
-            segmentation_f (optional): Segmentation method to be used for the project.
-            extraction_f (optional): Extraction method to be used for the project.
-            featurization_f (optional): Featurization method to be used for the project.
-            selection_f (optional): Selection method to be used for the project.
-            overwrite (optional): If set to ``True``, will overwrite existing files in the project directory. Default is ``False``.
-            debug (optional): If set to ``True``, will print additional debug messages/plots. Default is ``False``.
+            project_location: Path to the project directory.
+            config_path: Path to the config file.
+            segmentation_f: Segmentation method to be used for the project.
+            extraction_f: Extraction method to be used for the project.
+            featurization_f: Featurization method to be used for the project.
+            selection_f: Selection method to be used for the project.
+            overwrite: If set to ``True``, will overwrite existing files in the project directory. Default is ``False``.
+            debug: If set to ``True``, will print additional debug messages/plots. Default is ``False``.
         """
         super().__init__(directory=project_location, debug=debug)
 
@@ -258,7 +258,7 @@ class Project(Logable):
         Loads config from file and writes it to self.config
 
         Args:
-            file_path (str | os.PathLike[str]): Path to the config.yml file that should be loaded.
+            file_path: Path to the config.yml file that should be loaded.
         """
         self.log(f"Loading config from {file_path}")
 
@@ -275,10 +275,10 @@ class Project(Logable):
         """Load the config file for the project. If no config file is passed the default config file in the project directory is loaded.
 
         Args:
-            config_path (str | os.PathLike[str], optional): Path to the config file. Default is ``None``.
+            config_path: Path to the config file. Default is ``None``.
 
         Returns:
-            None: the config dictionary project.config is updated.
+            The config dictionary ``project.config`` is updated.
         """
         # load config file
         self.config_path = os.path.join(self.project_location, self.DEFAULT_CONFIG_NAME)
@@ -313,10 +313,10 @@ class Project(Logable):
         """Configure the segmentation method for the project.
 
         Args:
-            segmentation_f (Callable): Segmentation method to be used for the project.
+            segmentation_f: Segmentation method to be used for the project.
 
         Returns:
-            None: the segmentation method is updated in the project object.
+            The segmentation method is updated in the project object.
         """
         if segmentation_f is not None:
             if segmentation_f.__name__ not in self.config:
@@ -347,10 +347,10 @@ class Project(Logable):
         """Configure the extraction method for the project.
 
         Args:
-            extraction_f (Callable): Extraction method to be used for the project.
+            extraction_f: Extraction method to be used for the project.
 
         Returns:
-            None: the extraction method is updated in the project object.
+            The extraction method is updated in the project object.
         """
 
         if extraction_f is not None:
@@ -379,10 +379,10 @@ class Project(Logable):
         """Configure the featurization method for the project.
 
         Args:
-            featurization_f (Callable): Featurization method to be used for the project.
+            featurization_f: Featurization method to be used for the project.
 
         Returns:
-            None: the featurization method is updated in the project object.
+            The featurization method is updated in the project object.
         """
         if featurization_f is not None:
             if featurization_f.__name__ not in self.config:
@@ -410,7 +410,7 @@ class Project(Logable):
             featurization_f : The featurization method that should be used for the project.
 
         Returns:
-            None : the featurization method is updated in the project object.
+            The featurization method is updated in the project object.
 
         Examples:
             Update the featurization method for a project::
@@ -426,10 +426,10 @@ class Project(Logable):
         """Configure the selection method for the project.
 
         Args:
-            selection_f (Callable): Selection method to be used for the project.
+            selection_f: Selection method to be used for the project.
 
         Returns:
-            None: the selection method is updated in the project object.
+            The selection method is updated in the project object.
         """
         if self.selection_f is not None:
             if selection_f.__name__ not in self.config:
@@ -489,10 +489,10 @@ class Project(Logable):
         """Check if the image dtype is the default image dtype.
 
         Args:
-            image (np.ndarray): Image to be checked.
+            image: Image to be checked.
 
         Returns:
-            None: If the image dtype is the default image dtype, no action is taken.
+            If the image dtype is the default image dtype, no action is taken.
 
         Raises:
             Warning: If the image dtype is not the default image dtype.
@@ -512,10 +512,10 @@ class Project(Logable):
         Create a temporary directory in the specified directory with the name of the class.
 
         Args:
-            path (str): Path to the directory where the temporary directory should be created.
+            path: Path to the directory where the temporary directory should be created.
 
         Returns:
-            None: The temporary directory is created in the specified directory. The path to the temporary directory is stored in the project object as self._tmp_dir_path.
+            The temporary directory is created in the specified directory. The path to the temporary directory is stored in the project object as ``self._tmp_dir_path``.
 
         """
 
@@ -1062,14 +1062,14 @@ class Project(Logable):
         In the array the channels should be specified in the following order: nucleus, cytosol other channels.
 
         Args:
-            array (np.ndarray): Input image as a numpy array.
+            array: Input image as a numpy array.
             channel_names: List of channel names. Default is ``["channel_0", "channel_1", ...]``.
-            overwrite (bool, None, optional): If set to ``None``, will read the overwrite value from the associated project.
+            overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading.
             remap: List of integers that can be used to shuffle the order of the channels. For example ``[1, 0, 2]`` to invert the first two channels. Default is ``None`` in which case no reordering is performed.
                 This transform is also applied to the channel names.
         Returns:
-            None: Image is written to the project associated sdata object.
+            Image is written to the project associated sdata object.
 
             The input image can be accessed using the project object::
 
@@ -1138,17 +1138,17 @@ class Project(Logable):
             file_paths: List containing paths to each channel tiff file, like
                 ``["path1/img.tiff", "path2/img.tiff", "path3/img.tiff"]``
             channel_names: List of channel names. Default is ``["channel_0", "channel_1", ...]``.
-            crop (None, List[Tuple], optional): When set, it can be used to crop the input image.
+            crop: When set, it can be used to crop the input image.
                 The first element refers to the first dimension of the image and so on.
                 For example use ``[(0,1000),(0,2000)]`` to crop the image to 1000 px height and 2000 px width from the top left corner.
-            overwrite (bool, None, optional): If set to ``None``, will read the overwrite value from the associated project.
+            overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading.
             remap: List of integers that can be used to shuffle the order of the channels. For example ``[1, 0, 2]`` to invert the first two channels. Default is ``None`` in which case no reordering is performed.
                 This transform is also applied to the channel names.
             cache: path to a directory where the temporary files should be stored. Default is ``None`` then the current working directory will be used.
 
         Returns:
-            None: Image is written to the project associated sdata object.
+            Image is written to the project associated sdata object.
 
             The input image can be accessed using the project object::
 
@@ -1296,13 +1296,13 @@ class Project(Logable):
 
         Args:
             ome_zarr_path: Path to the ome-zarr file.
-            overwrite (bool, None, optional): If set to ``None``, will read the overwrite value from the associated project.
+            overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading.
             remap: List of integers that can be used to shuffle the order of the channels. For example ``[1, 0, 2]`` to invert the first two channels. Default is ``None`` in which case no reordering is performed.
                 This transform is also applied to the channel names.
 
         Returns:
-            None: Image is written to the project associated sdata object.
+            Image is written to the project associated sdata object.
 
             The input image can be accessed using the project object::
 
@@ -1367,11 +1367,11 @@ class Project(Logable):
         Args:
             dask_array: Dask array containing the input image.
             channel_names: List of channel names. Default is ``["channel_0", "channel_1", ...]``.
-            overwrite (bool, None, optional): If set to ``None``, will read the overwrite value from the associated project.
+            overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading.
 
         Returns:
-            None: Image is written to the project associated sdata object.
+            Image is written to the project associated sdata object.
 
             The input image can be accessed using the project object::
 
@@ -1432,13 +1432,13 @@ class Project(Logable):
             nucleus_segmentation_name: Name of the element in the spatial data object containing the nucleus segmentation mask. Default is ``None``.
             cytosol_segmentation_name: Name of the element in the spatial data object containing the cytosol segmentation mask. Default is ``None``.
             cell_id_identifier: column of annotating tables that contain the values that match a segmentation mask. If not provided it will assume this column carries the same name as the segmentation mask before parsing.
-            overwrite (bool, None, optional): If set to ``None``, will read the overwrite value from the associated project.
+            overwrite: If set to ``None``, will read the overwrite value from the associated project.
                 Otherwise can be set to a boolean value to override project specific settings for image loading.
             keep_all: If set to ``True``, will keep all existing elements in the sdata object in addition to renaming the desired ones. Default is ``True``.
             remove_duplicates: If keep_all and remove_duplicates is True then only one copy of the spatialdata elements selected for use with scportrait processing steps will be kept. Otherwise, the element will be saved both under the original as well as the new name.
 
         Returns:
-            None: Image is written to the project associated sdata object and self.sdata is updated.
+            Image is written to the project associated sdata object and ``self.sdata`` is updated.
         """
 
         # setup overwrite
@@ -1650,7 +1650,7 @@ class Project(Logable):
             output_folder_name: can be set to override the default output folder location.
 
         Returns:
-            None: Single-cell images are written to HDF5 files in the project associated extraction directory. File path can be accessed via ``project.extraction_f.output_path``.
+            Single-cell images are written to HDF5 files in the project associated extraction directory. The file path can be accessed via ``project.extraction_f.output_path``.
         """
         if self.extraction_f is None:
             raise ValueError("No extraction method defined")

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -16,7 +16,6 @@ import re
 import shutil
 import tempfile
 import warnings
-from pathlib import PosixPath
 from typing import TYPE_CHECKING, Literal
 
 import dask.array as da
@@ -172,10 +171,10 @@ class Project(Logable):
         """
         super().__init__(directory=project_location, debug=debug)
 
-        self.project_location = project_location
+        self.project_location = self.directory
         self.overwrite = overwrite
         self.config: None | dict = None
-        if config_path is None or isinstance(config_path, str | PosixPath):
+        if config_path is None or isinstance(config_path, (str, os.PathLike)):
             self._get_config_file(config_path)
         elif isinstance(config_path, dict):
             self._load_config_from_dict(config_path)

--- a/src/scportrait/pipeline/segmentation/workflows/_cellpose.py
+++ b/src/scportrait/pipeline/segmentation/workflows/_cellpose.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import os
 import timeit
-from pathlib import Path, PosixPath
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -92,7 +92,7 @@ class _CellposeSegmentation(_BaseSegmentation):
 
         elif "model_path" in self.config[f"{model_type}_segmentation"].keys():
             model_name = self.config[f"{model_type}_segmentation"]["model_path"]
-            if isinstance(model_name, PosixPath):
+            if isinstance(model_name, os.PathLike):
                 model_name = str(model_name)
             model = self._read_cellpose_model("custom", model_name, gpu=gpu, device=device)
 

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -1,22 +1,23 @@
 import os
-from collections.abc import Callable, Iterable
-from typing import Any
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import h5py
 import numpy as np
 import torch
 from torch.utils.data import Dataset
 
+from scportrait._utils.paths import normalize_path, path_suffix
 from scportrait.pipeline._utils.constants import IMAGE_DATACONTAINER_NAME, INDEX_DATACONTAINER_NAME
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _check_type_input_list(var):
     return isinstance(var, Iterable) and all(
         isinstance(sublist, Iterable) and all(isinstance(item, int) for item in sublist) for sublist in var
     )
-
-
-from pathlib import PosixPath
 
 
 class _HDF5SingleCellDataset(Dataset):
@@ -37,7 +38,7 @@ class _HDF5SingleCellDataset(Dataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         index_list: list[list[int]] | None = None,
         select_channel: list[int] | int | None = None,
         transform=None,
@@ -45,10 +46,7 @@ class _HDF5SingleCellDataset(Dataset):
         max_level: int = 5,
     ):
         """ """
-        self.dir_list = dir_list
-
-        if isinstance(self.dir_list[0], PosixPath):
-            self.dir_list = [str(x) for x in self.dir_list]
+        self.dir_list = [normalize_path(path) for path in dir_list]
 
         # ensure select_channel is always a list
         if isinstance(select_channel, int):
@@ -83,21 +81,22 @@ class _HDF5SingleCellDataset(Dataset):
         self.bulk_labels: list[int] | None = None
         self.label_column: int | None = None
 
-    def get_hdf(self, path: str) -> h5py.File:
+    def get_hdf(self, path: str | os.PathLike[str]) -> h5py.File:
         """
         Retrieve (or lazily create) a *process-local* file handle.
         """
-        file = self._open_hdf.get(path)
+        normalized_path = os.fspath(path)
+        file = self._open_hdf.get(normalized_path)
 
         if file is None:  # first call in this process
-            file = h5py.File(path, mode="r")
-            self._open_hdf[path] = file
+            file = h5py.File(normalized_path, mode="r")
+            self._open_hdf[normalized_path] = file
 
         return file
 
     def _add_hdf_to_index(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         index_list: list[int] | None = None,
         label: int | None = None,
         label_column: int | None = None,
@@ -108,14 +107,15 @@ class _HDF5SingleCellDataset(Dataset):
         """
         Adds single cell data from the hdf5 file located at `path` with the specified `current_label` to the index.
         """
+        normalized_path: Path = normalize_path(path)
 
         # check to ensure that HDF5 file exists
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"File {path} not found. Please ensure that the file exists.")
+        if not normalized_path.exists():
+            raise FileNotFoundError(f"File {normalized_path} not found. Please ensure that the file exists.")
 
         try:
             # connect to h5py file
-            input_hdf = h5py.File(path, "r")
+            input_hdf = h5py.File(normalized_path, "r")
 
             # get single cell index handle
             if index_list != [None]:
@@ -126,7 +126,7 @@ class _HDF5SingleCellDataset(Dataset):
                 max_index = max(index_list)
 
                 assert max_index < max_elements, (
-                    f"Index {max_index} is out of bounds for file {path}. Only {max_elements} single cell records available in dataset."
+                    f"Index {max_index} is out of bounds for file {normalized_path}. Only {max_elements} single cell records available in dataset."
                 )
 
                 for i, ix in enumerate(index_list):
@@ -144,7 +144,7 @@ class _HDF5SingleCellDataset(Dataset):
 
             # add connection to singe cell datasets
             handle_id = len(self.paths)
-            self.paths.append(path)  # add path to new dataset to list of paths
+            self.paths.append(os.fspath(normalized_path))  # add path to new dataset to list of paths
 
             # add single-cell labelling
             if read_label:
@@ -188,7 +188,7 @@ class _HDF5SingleCellDataset(Dataset):
 
     def _add_dataset(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         current_index_list: list[int],
         id: int,
         read_label_from_dataset: bool,
@@ -224,7 +224,7 @@ class _HDF5SingleCellDataset(Dataset):
 
     def _scan_directory(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         levels_left: int,
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
@@ -245,21 +245,20 @@ class _HDF5SingleCellDataset(Dataset):
         # hdf5 files are added to the index
         # subfolders are recursively scanned
 
+        normalized_path: Path = normalize_path(path)
+
         if levels_left > 0:
             # get files and directories at current level
 
-            current_level_directories = [
-                os.path.join(path, name) for name in os.listdir(path) if os.path.isdir(os.path.join(path, name))
-            ]
+            current_level_directories = [entry for entry in normalized_path.iterdir() if entry.is_dir()]
+            current_level_files = [entry for entry in normalized_path.iterdir() if entry.is_file()]
 
-            current_level_files = [name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))]
-
-            for i, file in enumerate(current_level_files):
-                filetype = file.split(".")[-1]
+            for i, file_path in enumerate(current_level_files):
+                filetype = path_suffix(file_path)
 
                 if filetype in self.HDF_FILETYPES:
                     self._add_dataset(
-                        path=file,
+                        path=file_path,
                         current_index_list=current_index_list,
                         id=i,
                         read_label_from_dataset=read_label_from_dataset,
@@ -296,18 +295,18 @@ class _HDF5SingleCellDataset(Dataset):
 
         # scan all directories provided
         for i, directory in enumerate(self.dir_list):
-            path = os.path.abspath(directory)
+            path = directory.resolve()
             current_index_list = self.index_list[i]
 
             # get current label
             # self._get_dataset_label(i) has not been implemented yet
 
             # check if "directory" is a path to specific hdf5
-            filetype = directory.split(".")[-1]
+            filetype = path_suffix(path)
 
             if filetype in self.HDF_FILETYPES:
                 self._add_dataset(
-                    path=directory,
+                    path=path,
                     current_index_list=current_index_list,
                     id=i,
                     read_label_from_dataset=read_label_from_dataset,
@@ -440,7 +439,7 @@ class HDF5SingleCellDataset(_HDF5SingleCellDataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         dir_labels: list[int],
         index_list: list[list[int]] | None = None,  # list of indices to select from the index
         transform=None,
@@ -509,7 +508,7 @@ class LabelledHDF5SingleCellDataset(_HDF5SingleCellDataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         label_colum: int,
         label_dtype: type,
         label_column_transform: Callable | None = None,
@@ -558,17 +557,14 @@ class _H5ScSingleCellDataset(Dataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         index_list: list[list[int]] | None = None,
         select_channel: list[int] | int | None = None,
         transform=None,
         return_id: bool = True,
         max_level: int = 5,
     ):
-        self.dir_list = dir_list
-
-        if isinstance(self.dir_list[0], PosixPath):
-            self.dir_list = [str(x) for x in self.dir_list]
+        self.dir_list = [normalize_path(path) for path in dir_list]
 
         # ensure select_channel is always a list
         if isinstance(select_channel, int):
@@ -604,7 +600,7 @@ class _H5ScSingleCellDataset(Dataset):
 
     def _add_hdf_to_index(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         index_list: list[int] | None = None,
         label: int | None = None,
         label_column: str | None = None,
@@ -614,17 +610,18 @@ class _H5ScSingleCellDataset(Dataset):
         """
         Adds single cell data from the hdf5 file located at `path` with the specified `current_label` to the index.
         """
+        normalized_path: Path = normalize_path(path)
 
         # check to ensure that HDF5 file exists
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"File {path} not found. Please ensure that the file exists.")
+        if not normalized_path.exists():
+            raise FileNotFoundError(f"File {normalized_path} not found. Please ensure that the file exists.")
 
         try:
             # connect to h5py file
-            input_hdf = h5py.File(path, "r")
+            input_hdf = h5py.File(normalized_path, "r")
 
             # ensure that the file is encoded with anndata
-            assert input_hdf.attrs["encoding-type"] == "anndata", f"File {path} is not an anndata file. "
+            assert input_hdf.attrs["encoding-type"] == "anndata", f"File {normalized_path} is not an anndata file. "
 
             # get single cell index handle
             if index_list != [None]:
@@ -636,7 +633,7 @@ class _H5ScSingleCellDataset(Dataset):
                 max_index = max(index_list)
 
                 assert max_index < max_elements, (
-                    f"Index {max_index} is out of bounds for file {path}. Only {max_elements} single cell records available in dataset."
+                    f"Index {max_index} is out of bounds for file {normalized_path}. Only {max_elements} single cell records available in dataset."
                 )
 
                 for i, ix in enumerate(index_list):
@@ -694,7 +691,7 @@ class _H5ScSingleCellDataset(Dataset):
 
     def _add_dataset(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         current_index_list: list[int],
         id: int,
         read_label_from_dataset: bool,
@@ -728,7 +725,7 @@ class _H5ScSingleCellDataset(Dataset):
 
     def _scan_directory(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         levels_left: int,
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
@@ -749,21 +746,20 @@ class _H5ScSingleCellDataset(Dataset):
         # hdf5 files are added to the index
         # subfolders are recursively scanned
 
+        normalized_path: Path = normalize_path(path)
+
         if levels_left > 0:
             # get files and directories at current level
 
-            current_level_directories = [
-                os.path.join(path, name) for name in os.listdir(path) if os.path.isdir(os.path.join(path, name))
-            ]
+            current_level_directories = [entry for entry in normalized_path.iterdir() if entry.is_dir()]
+            current_level_files = [entry for entry in normalized_path.iterdir() if entry.is_file()]
 
-            current_level_files = [name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))]
-
-            for i, file in enumerate(current_level_files):
-                filetype = file.split(".")[-1]
+            for i, file_path in enumerate(current_level_files):
+                filetype = path_suffix(file_path)
 
                 if filetype in self.HDF_FILETYPES:
                     self._add_dataset(
-                        path=file,
+                        path=file_path,
                         current_index_list=current_index_list,
                         id=i,
                         read_label_from_dataset=read_label_from_dataset,
@@ -800,18 +796,18 @@ class _H5ScSingleCellDataset(Dataset):
 
         # scan all directories provided
         for i, directory in enumerate(self.dir_list):
-            path = os.path.abspath(directory)
+            path = directory.resolve()
             current_index_list = self.index_list[i]
 
             # get current label
             # self._get_dataset_label(i) has not been implemented yet
 
             # check if "directory" is a path to specific hdf5
-            filetype = directory.split(".")[-1]
+            filetype = path_suffix(path)
 
             if filetype in self.HDF_FILETYPES:
                 self._add_dataset(
-                    path=directory,
+                    path=path,
                     current_index_list=current_index_list,
                     id=i,
                     read_label_from_dataset=read_label_from_dataset,
@@ -950,7 +946,7 @@ class H5ScSingleCellDataset(_H5ScSingleCellDataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         dir_labels: list[int],
         index_list: list[list[int]] | None = None,  # list of indices to select from the index
         transform=None,
@@ -1021,7 +1017,7 @@ class LabelledH5ScSingleCellDataset(_H5ScSingleCellDataset):
 
     def __init__(
         self,
-        dir_list: list[str],
+        dir_list: Sequence[str | os.PathLike[str]],
         label_colum: str,
         label_column_transform: Callable | None = None,
         index_list: list[list[int]] | None = None,  # list of indices to select from the index

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -13,6 +13,7 @@ import sys
 import warnings
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -21,9 +22,6 @@ from tifffile import imread, imwrite
 from tqdm.auto import tqdm
 
 from scportrait._utils.paths import normalize_path
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _get_child_name(elem):
@@ -76,7 +74,7 @@ class PhenixParser:
         self.missing_images_copy: list[str] = []
         self.outdirs: dict[str, Path] = {}
 
-    def _get_xml_path(self) -> str | os.PathLike[str]:
+    def _get_xml_path(self) -> Path:
         """Automatically gets the path to the XML file containing metadata."""
 
         # directory depends on if flatfield images were exported or not
@@ -101,7 +99,7 @@ class PhenixParser:
 
         return index_file
 
-    def _get_input_dir(self) -> str | os.PathLike[str]:
+    def _get_input_dir(self) -> Path:
         """Automatically get the subfolder where the exported image files are located."""
         # directory depends on if flatfield images were exported or not
         # these generated folder structures are hard coded during phenix export, do not change
@@ -942,7 +940,7 @@ class CombinedPhenixParser(PhenixParser):
             experiment_dir, flatfield_exported, use_symlinks, compress_rows, compress_cols, overwrite=overwrite
         )
 
-    def _get_xml_path(self):
+    def _get_xml_path(self) -> Path:
         """Automatically get the XML files from all phenix experiments that should be combined."""
         # directory depends on if flatfield images were exported or not
         # these generated folder structures are hard coded during phenix export, do not change
@@ -966,7 +964,7 @@ class CombinedPhenixParser(PhenixParser):
 
         return index_file
 
-    def _get_input_dir(self) -> str:
+    def _get_input_dir(self) -> Path:
         """Automatically get the subfolder where the exported image files are located."""
 
         # directory depends on if flatfield images were exported or not

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -1030,9 +1030,10 @@ class CombinedPhenixParser(PhenixParser):
         # read all metadata
         metadata = {}
         for phenix_dir in self.phenix_dirs:
-            df = self._read_phenix_xml(phenix_dir / xml_path)
-            df.loc[:, "source"] = str(phenix_dir / append_string)  # update source with the correct strings
-            metadata[phenix_dir] = df
+            normalized_phenix_dir = normalize_path(phenix_dir)
+            df = self._read_phenix_xml(normalized_phenix_dir / xml_path)
+            df.loc[:, "source"] = str(normalized_phenix_dir / append_string)  # update source with the correct strings
+            metadata[str(normalized_phenix_dir)] = df
 
         metadata_combined = pd.concat(metadata.values(), ignore_index=True)
         metadata_combined = self._assign_tile_positions(metadata_combined)

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -13,12 +13,17 @@ import sys
 import warnings
 import xml.etree.ElementTree as ET
 from datetime import datetime
-from pathlib import PosixPath
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from tifffile import imread, imwrite
 from tqdm.auto import tqdm
+
+from scportrait._utils.paths import normalize_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _get_child_name(elem):
@@ -32,7 +37,7 @@ class PhenixParser:
 
     def __init__(
         self,
-        experiment_dir: str | PosixPath,
+        experiment_dir: str | os.PathLike[str],
         flatfield_exported: bool = True,
         use_symlinks: bool = True,
         compress_rows: bool = False,
@@ -48,7 +53,7 @@ class PhenixParser:
             compress_cols: Whether to merge all wells into a single parsed column.
             overwrite: Whether to overwrite existing files during the parsing process.
         """
-        self.experiment_dir = experiment_dir
+        self.experiment_dir = normalize_path(experiment_dir)
         self.export_symlinks = use_symlinks
         self.flatfield_status = flatfield_exported
         self.compress_rows = compress_rows
@@ -69,9 +74,9 @@ class PhenixParser:
         self.channel_lookup = self._get_channel_metadata(self.xml_path)
         self.metadata: None | pd.DataFrame = None
         self.missing_images_copy: list[str] = []
-        self.outdirs: dict[str, str] = {}
+        self.outdirs: dict[str, Path] = {}
 
-    def _get_xml_path(self) -> str | PosixPath:
+    def _get_xml_path(self) -> str | os.PathLike[str]:
         """Automatically gets the path to the XML file containing metadata."""
 
         # directory depends on if flatfield images were exported or not
@@ -80,33 +85,33 @@ class PhenixParser:
         if self.flatfield_status:
             index_file_names = ["Index.xml", "Index.ref.xml"]
             for index_file_name in index_file_names:
-                index_file = os.path.join(self.experiment_dir, "Images", index_file_name)
-                if os.path.isfile(index_file):
+                index_file = self.experiment_dir / "Images" / index_file_name
+                if index_file.is_file():
                     break
         else:
             index_file_names = ["Index.xml", "Index.idx.xml"]
             for index_file_name in index_file_names:
-                index_file = os.path.join(self.experiment_dir, "Images", index_file_name)
-                if os.path.isfile(index_file):
+                index_file = self.experiment_dir / "Images" / index_file_name
+                if index_file.is_file():
                     break
 
         # perform sanity check if file exists else exit
-        if not os.path.isfile(index_file):
+        if not index_file.is_file():
             sys.exit(f"Can not find index file at path: {index_file}")
 
         return index_file
 
-    def _get_input_dir(self) -> str | PosixPath:
+    def _get_input_dir(self) -> str | os.PathLike[str]:
         """Automatically get the subfolder where the exported image files are located."""
         # directory depends on if flatfield images were exported or not
         # these generated folder structures are hard coded during phenix export, do not change
         if self.flatfield_status:
-            input_dir = os.path.join(self.experiment_dir, "Images", "flex")
+            input_dir = self.experiment_dir / "Images" / "flex"
         else:
-            input_dir = os.path.join(self.experiment_dir, "Images")
+            input_dir = self.experiment_dir / "Images"
 
         # perform sanity check if file exists else exit
-        if not os.path.isdir(input_dir):
+        if not input_dir.is_dir():
             sys.exit(f"Can not find directory containing images to parse: {input_dir}")
 
         return input_dir
@@ -118,13 +123,13 @@ class PhenixParser:
             name: Name of the output directory.
         """
 
-        self.outdirs[name] = f"{self.experiment_dir}/{name}"
+        self.outdirs[name] = self.experiment_dir / name
 
         # if output directory did not exist create it
-        if not os.path.isdir(self.outdirs[name]):
-            os.makedirs(self.outdirs[name])
+        if not self.outdirs[name].is_dir():
+            self.outdirs[name].mkdir(parents=True, exist_ok=True)
 
-    def _get_channel_metadata(self, xml_path: str | PosixPath) -> pd.DataFrame:
+    def _get_channel_metadata(self, xml_path: str | os.PathLike[str]) -> pd.DataFrame:
         """Parse channel metadata from the exported Phenix index XML.
 
         Args:
@@ -133,7 +138,7 @@ class PhenixParser:
         Returns:
             A lookup table for channel names and IDs.
         """
-        index_file = xml_path
+        index_file = normalize_path(xml_path)
 
         # Read and parse the XML file
         with open(index_file) as f:
@@ -162,15 +167,16 @@ class PhenixParser:
         print(lookup, "\n")
 
         # Save lookup file to csv
-        lookup.to_csv(f"{self.experiment_dir}/channel_lookuptable.csv")
-        print(f"Channel Lookup table saved to file at {self.experiment_dir}/channel_lookuptable.csv\n")
+        lookup_path = self.experiment_dir / "channel_lookuptable.csv"
+        lookup.to_csv(lookup_path)
+        print(f"Channel Lookup table saved to file at {lookup_path}\n")
 
         # Set channel names
         self.channel_names = channel_names
 
         return lookup
 
-    def _read_phenix_xml(self, xml_path: str | PosixPath) -> pd.DataFrame:
+    def _read_phenix_xml(self, xml_path: str | os.PathLike[str]) -> pd.DataFrame:
         """Read and parse the XML file containing metadata from a Phenix experiment.
 
         Args:
@@ -195,7 +201,7 @@ class PhenixParser:
         url = []
 
         # extract information from XML file
-        tree = ET.parse(xml_path)
+        tree = ET.parse(normalize_path(xml_path))
         root = tree.getroot()
 
         # get Harmony Version number
@@ -311,8 +317,9 @@ class PhenixParser:
             _image_names = [f"flex_{x}" for x in image_names]
             status = False
             for img in _image_names:
-                path = os.path.join(self.image_dir, img)
-                if os.path.exists(path):
+                image_dir: Path = normalize_path(self.image_dir)
+                path = image_dir / img
+                if path.exists():
                     status = True
                     break
             if status:
@@ -625,8 +632,8 @@ class PhenixParser:
             # get size of missing images that need to be replaced
             image = None
             for source, file in zip(metadata["source"], metadata["filename"], strict=True):
-                path = os.path.join(source, file)
-                if os.path.exists(path):
+                path = normalize_path(source) / file
+                if path.exists():
                     image = imread(path)
                     break
             if image is None:
@@ -657,7 +664,7 @@ class PhenixParser:
         if len(self.missing_images) > 0:
             for missing_image in self.missing_images:
                 print(f"Creating black image with name: {missing_image}")
-                imwrite(os.path.join(self.outdirs["parsed_images"], missing_image), self.black_image)
+                imwrite(self.outdirs["parsed_images"] / missing_image, self.black_image)
 
             print(
                 f"All missing images successfully replaced with black images of the dimension {self.black_image.shape}"
@@ -669,13 +676,15 @@ class PhenixParser:
 
             def copyfunction(input, output):
                 try:
+                    input = normalize_path(input)
+                    output = normalize_path(output)
                     if platform.system() == "Windows":
                         warnings.warn(
                             "\n\nWindows detected as platform. Symlinks cannot be used on Windows. Using hard links instead.\n\n",
                             stacklevel=2,
                         )
                         # On Windows, use hard links when symlinks are requested
-                        if not os.path.exists(output):
+                        if not output.exists():
                             os.link(input, output)
                     else:
                         # Unix symlink behavior
@@ -687,8 +696,10 @@ class PhenixParser:
 
             def copyfunction(input, output):
                 try:
+                    input = normalize_path(input)
+                    output = normalize_path(output)
                     # Create destination directory if it doesn't exist
-                    os.makedirs(os.path.dirname(output), exist_ok=True)
+                    output.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copyfile(input, output)
                 except OSError as e:
                     print("Error: ", e)
@@ -719,13 +730,13 @@ class PhenixParser:
             desc="Copying files",
         ):
             # define old and new paths for copy process
-            old_path = os.path.join(source, old)
-            new_path = os.path.join(dest, new)
+            old_path = normalize_path(source) / old
+            new_path = normalize_path(dest) / new
             # check if old path exists
-            if os.path.exists(old_path):
-                if os.path.exists(new_path):
+            if old_path.exists():
+                if new_path.exists():
                     if self.overwrite:
-                        os.remove(new_path)
+                        new_path.unlink()
                         self.copyfunction(old_path, new_path)
                     else:
                         self.copyfunction(old_path, new_path)
@@ -741,8 +752,9 @@ class PhenixParser:
 
     def _save_metadata(self, metadata: pd.DataFrame) -> None:
         """Save metadata used to parse images to a csv file."""
-        metadata.to_csv(f"{self.experiment_dir}/metadata_image_parsing.csv")
-        print(f"Metadata used to parse images saved to file {self.experiment_dir}/metadata_image_parsing.csv")
+        metadata_path = self.experiment_dir / "metadata_image_parsing.csv"
+        metadata.to_csv(metadata_path)
+        print(f"Metadata used to parse images saved to file {metadata_path}")
 
     def parse(self, check_missing_tiles: bool = True) -> None:
         """Complete parsing of the Phenix experiment.
@@ -804,12 +816,12 @@ class PhenixParser:
             print("\t Tiles: ", tiles)  # only print if these folders should be created
             # update metadata to include destination for each tile
             metadata["dest"] = [
-                os.path.join(self.outdirs["sorted_wells"], f"row{row}_well{well}", tile)
+                str(self.outdirs["sorted_wells"] / f"row{row}_well{well}" / tile)
                 for row, well, tile in zip(metadata.Row, metadata.Well, metadata.tiles, strict=False)
             ]
         else:
             metadata["dest"] = [
-                os.path.join(self.outdirs["sorted_wells"], f"row{row}_well{well}")
+                str(self.outdirs["sorted_wells"] / f"row{row}_well{well}")
                 for row, well in zip(metadata.Row, metadata.Well, strict=False)
             ]
 
@@ -817,8 +829,7 @@ class PhenixParser:
         unique_dirs = list(set(metadata.dest.to_list()))
 
         for _dir in unique_dirs:
-            if not os.path.exists(_dir):
-                os.makedirs(_dir)
+            normalize_path(_dir).mkdir(parents=True, exist_ok=True)
 
         # copy/link the images to their new names
         self._copy_files(metadata=metadata)
@@ -860,20 +871,17 @@ class PhenixParser:
         if sort_wells:
             # update metadata to include destination for each tile
             metadata["dest"] = [
-                os.path.join(self.outdirs["sorted_timepoints"], timepoint, f"{row}_{well}")
+                str(self.outdirs["sorted_timepoints"] / timepoint / f"{row}_{well}")
                 for row, well, timepoint in zip(metadata.Row, metadata.Well, metadata.Timepoint, strict=False)
             ]
         else:
-            metadata["dest"] = [
-                os.path.join(self.outdirs["sorted_timepoints"], timepoint) for timepoint in metadata.Timepoint
-            ]
+            metadata["dest"] = [str(self.outdirs["sorted_timepoints"] / timepoint) for timepoint in metadata.Timepoint]
 
         # unique directories for each tile
         unique_dirs = list(set(metadata.dest.to_list()))
 
         for _dir in unique_dirs:
-            if not os.path.exists(_dir):
-                os.makedirs(_dir)
+            normalize_path(_dir).mkdir(parents=True, exist_ok=True)
 
         # copy/link the images to their new names
         self._copy_files(metadata=metadata)
@@ -912,7 +920,7 @@ class CombinedPhenixParser(PhenixParser):
 
     def __init__(
         self,
-        experiment_dir: str,
+        experiment_dir: str | os.PathLike[str],
         flatfield_exported: bool = True,
         use_symlinks: bool = True,
         compress_rows: bool = False,
@@ -928,7 +936,7 @@ class CombinedPhenixParser(PhenixParser):
             compress_cols: Whether to merge all wells into a single parsed column.
             overwrite: Whether to overwrite existing files during the parsing process.
         """
-        self.experiment_dir = experiment_dir
+        self.experiment_dir = normalize_path(experiment_dir)
         self.get_datasets_to_combine()
         super().__init__(
             experiment_dir, flatfield_exported, use_symlinks, compress_rows, compress_cols, overwrite=overwrite
@@ -942,18 +950,18 @@ class CombinedPhenixParser(PhenixParser):
         if self.flatfield_status:
             index_file_names = ["Index.xml", "Index.ref.xml"]
             for index_file_name in index_file_names:
-                index_file = os.path.join(self.phenix_dirs[0], "Images", index_file_name)
-                if os.path.isfile(index_file):
+                index_file = self.phenix_dirs[0] / "Images" / index_file_name
+                if index_file.is_file():
                     break
         else:
             index_file_names = ["Index.xml", "Index.idx.xml"]
             for index_file_name in index_file_names:
-                index_file = os.path.join(self.phenix_dirs[0], "Images", index_file_name)
-                if os.path.isfile(index_file):
+                index_file = self.phenix_dirs[0] / "Images" / index_file_name
+                if index_file.is_file():
                     break
 
         # perform sanity check if file exists else exit
-        if not os.path.isfile(index_file):
+        if not index_file.is_file():
             sys.exit(f"Can not find index file at path: {index_file}")
 
         return index_file
@@ -965,22 +973,22 @@ class CombinedPhenixParser(PhenixParser):
         # these generated folder structures are hard coded during phenix export, do not change
         # for the combined exported the first experiment is always used (they should have the same exported XML file anyways for reading)
         if self.flatfield_status:
-            input_dir = f"{self.phenix_dirs[0]}/Images/flex"
+            input_dir = self.phenix_dirs[0] / "Images" / "flex"
         else:
-            input_dir = f"{self.phenix_dirs[0]}/Images"
+            input_dir = self.phenix_dirs[0] / "Images"
 
         # perform sanity check if file exists else exit
-        if not os.path.isdir(input_dir):
+        if not input_dir.is_dir():
             sys.exit(f"Can not find directory containing images to parse: {input_dir}")
 
         return input_dir
 
     def get_datasets_to_combine(self) -> None:
         """Get all Phenix experiments from subdirectories that should be combined."""
-        input_path = f"{self.experiment_dir}/{self.directory_combined_measurements}"
+        input_path = self.experiment_dir / self.directory_combined_measurements
 
         # get phenix directories that need to be combined together
-        phenix_dirs = os.listdir(input_path)
+        phenix_dirs = [entry.name for entry in input_path.iterdir() if entry.is_dir()]
 
         # only get the phenix dirs that match the pattern of a phenix experiment (ie they contain a time stamp)
         pattern = r"\d{4}-\d{2}-\d{2}T\d{2}_\d{2}_\d{2}"
@@ -996,7 +1004,7 @@ class CombinedPhenixParser(PhenixParser):
         # Sort the file names based on the extracted date and time information
         sorted_phenix_dirs = [file_name for _, file_name in sorted(zip(dates_times, phenix_dirs, strict=False))]
 
-        self.phenix_dirs = [f"{input_path}/{phenix_dir}" for phenix_dir in sorted_phenix_dirs]
+        self.phenix_dirs = [input_path / phenix_dir for phenix_dir in sorted_phenix_dirs]
 
     def _get_phenix_metadata(self) -> pd.DataFrame:
         """Read combined metadata from all Phenix experiments.
@@ -1024,8 +1032,8 @@ class CombinedPhenixParser(PhenixParser):
         # read all metadata
         metadata = {}
         for phenix_dir in self.phenix_dirs:
-            df = self._read_phenix_xml(f"{phenix_dir}/{xml_path}")
-            df.loc[:, "source"] = f"{phenix_dir}/{append_string}"  # update source with the correct strings
+            df = self._read_phenix_xml(phenix_dir / xml_path)
+            df.loc[:, "source"] = str(phenix_dir / append_string)  # update source with the correct strings
             metadata[phenix_dir] = df
 
         metadata_combined = pd.concat(metadata.values(), ignore_index=True)

--- a/src/scportrait/tools/parse/_parse_phenix.py
+++ b/src/scportrait/tools/parse/_parse_phenix.py
@@ -1031,7 +1031,7 @@ class CombinedPhenixParser(PhenixParser):
         metadata = {}
         for phenix_dir in self.phenix_dirs:
             normalized_phenix_dir = normalize_path(phenix_dir)
-            df = self._read_phenix_xml(normalized_phenix_dir / xml_path)
+            df = self._read_phenix_xml(os.fspath(normalized_phenix_dir / xml_path))
             df.loc[:, "source"] = str(normalized_phenix_dir / append_string)  # update source with the correct strings
             metadata[str(normalized_phenix_dir)] = df
 

--- a/tests/unit_tests/pipeline/test_base.py
+++ b/tests/unit_tests/pipeline/test_base.py
@@ -8,6 +8,14 @@ import yaml
 from scportrait.pipeline._base import Logable, ProcessingStep
 
 
+class _PathLikeConfig:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def __fspath__(self) -> str:
+        return str(self.path)
+
+
 def _read_log_content(logable: Logable, tmp_path) -> str:
     log_path = tmp_path / logable.DEFAULT_LOG_NAME
     return log_path.read_text()
@@ -44,14 +52,15 @@ def test_logable_log_writes_expected_message_shapes(tmp_path, message, expected_
         assert expected in log_content
 
 
-@pytest.mark.parametrize("config_source", ["dict", "path"])
+@pytest.mark.parametrize("config_source", ["dict", "path", "pathlike"])
 def test_processing_step_init_normalizes_config_from_supported_sources(tmp_path, config_source):
     """ProcessingStep should accept both dict configs and config file paths."""
     config_dict = {"cache": str(tmp_path / "cache"), "setting1": "value1"}
-    if config_source == "path":
+    if config_source in {"path", "pathlike"}:
         config_path = tmp_path / "config.yml"
         config_path.write_text(yaml.safe_dump(config_dict))
-        processing_step = ProcessingStep(config_path, tmp_path / "test_step", tmp_path, debug=True)
+        config_input = config_path if config_source == "path" else _PathLikeConfig(config_path)
+        processing_step = ProcessingStep(config_input, tmp_path / "test_step", tmp_path, debug=True)
     else:
         processing_step = ProcessingStep(config_dict, tmp_path / "test_step", tmp_path, debug=True)
 


### PR DESCRIPTION
# Fix Windows config-path handling in ProcessingStep

## Summary

This PR updates `ProcessingStep` config path handling so config files are detected in a platform-neutral way.

Previously, `ProcessingStep` accepted string paths and `PosixPath` instances, but not `WindowsPath` instances. On Windows, `pytest` `tmp_path` produces `pathlib.WindowsPath`, so config file paths were incorrectly treated as parsed config dictionaries. This caused `ProcessingStep` to call `.get(...)` on a `WindowsPath` object and fail during unit tests.

## Problem

Running the unit test suite on Windows exposed the following failure:

```
FAILED tests/unit_tests/pipeline/test_base.py::test_processing_step_init_normalizes_config_from_supported_sources[path]
```

With the error:

```
AttributeError: 'WindowsPath' object has no attribute 'get'
```

The failure occurred because `ProcessingStep` checked specifically for `PosixPath` when deciding whether config should be read from disk. That works on Linux/macOS but fails on Windows.

## Changes

This PR replaces the platform-specific path check with a platform-neutral one.

`ProcessingStep` now correctly handles config inputs such as:

* `str`
* `pathlib.PosixPath`
* `pathlib.WindowsPath`
* standard `pathlib.Path` instances

This keeps the existing behaviour for string and POSIX paths while adding proper support for Windows paths.

## Why this matters

This makes config-path initialisation portable across Windows, Linux, and macOS.

It also removes a small but important platform assumption from the pipeline base class. Since contributors may run tests locally on Windows, `ProcessingStep` should not rely on POSIX-specific path types.

## Testing

Tested on Windows with:

* Python 3.12.13
* pytest 9.0.3
* Conda environment: `scportrait312`

Relevant test:

```
python -m pytest tests/unit_tests/pipeline/test_base.py::test_processing_step_init_normalizes_config_from_supported_sources --disable-warnings
```

Expected result:

* dict config input passes
* path config input passes

## Notes

This PR is intentionally small and focused. It only addresses platform-neutral config path handling in `ProcessingStep`.
