### PR TITLE
Add explicit close lifecycle for HDF5/H5SC dataset handles

### DIFF
--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -95,6 +95,28 @@ class _HDF5SingleCellDataset(Dataset):
 
         return file
 
+    def close(self) -> None:
+        """Close all opened HDF5 file handles."""
+        for file in self._open_hdf.values():
+            if file is not None:
+                try:
+                    file.close()
+                except Exception:
+                    continue
+        self._open_hdf.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _add_hdf_to_index(
         self,
         path: str,
@@ -113,6 +135,7 @@ class _HDF5SingleCellDataset(Dataset):
         if not os.path.exists(path):
             raise FileNotFoundError(f"File {path} not found. Please ensure that the file exists.")
 
+        input_hdf = None
         try:
             # connect to h5py file
             input_hdf = h5py.File(path, "r")
@@ -180,11 +203,12 @@ class _HDF5SingleCellDataset(Dataset):
                 for row in index_handle:
                     self.data_locator.append([label, handle_id] + list(row))
 
-            input_hdf.close()
-
         except (FileNotFoundError, KeyError, OSError) as e:
             print(f"Error: {e}")
             return
+        finally:
+            if input_hdf is not None:
+                input_hdf.close()
 
     def _add_dataset(
         self,
@@ -597,10 +621,33 @@ class _H5ScSingleCellDataset(Dataset):
 
         # initialize placeholders to store dataset information
         self.handle_list: list[Any] = []
+        self._open_hdf: list[h5py.File] = []
         self.data_locator: list[list[int]] = []
 
         self.bulk_labels: list[int] | None = None
         self.label_column: str | None = None
+
+    def close(self) -> None:
+        """Close all opened HDF5 file handles."""
+        for file in self._open_hdf:
+            try:
+                file.close()
+            except Exception:
+                continue
+        self._open_hdf.clear()
+        self.handle_list.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _add_hdf_to_index(
         self,
@@ -619,6 +666,8 @@ class _H5ScSingleCellDataset(Dataset):
         if not os.path.exists(path):
             raise FileNotFoundError(f"File {path} not found. Please ensure that the file exists.")
 
+        input_hdf = None
+        keep_file_open = False
         try:
             # connect to h5py file
             input_hdf = h5py.File(path, "r")
@@ -655,11 +704,9 @@ class _H5ScSingleCellDataset(Dataset):
                     f"Selected channels are out of bounds. Maximum available channelid is {max_channels}."
                 )
 
-            # add connection to singe cell datasets
+            # prepare entries for new dataset
             handle_id = len(self.handle_list)
-            self.handle_list.append(
-                input_hdf.get(self.IMAGE_DATACONTAINTER_NAME)
-            )  # add new dataset to list of datasets
+            new_locator_entries: list[list[Any]] = []
 
             # add single-cell labelling
             if read_label:
@@ -679,18 +726,28 @@ class _H5ScSingleCellDataset(Dataset):
                 # iterate over rows in index handle, i.e. over all cells
                 for current_target, index, cell_id in zip(label_col, index_handle, cell_id_handle, strict=True):
                     # append target, handle id, and row to data locator
-                    self.data_locator.append([current_target, handle_id, index, cell_id])
+                    new_locator_entries.append([current_target, handle_id, index, cell_id])
 
             else:
                 assert label is not None, "Label must be provided if read_label is set to False."
 
                 # generate identifiers for all single-cells
                 for index, cell_id in zip(index_handle, cell_id_handle, strict=True):
-                    self.data_locator.append([label, handle_id, index, cell_id])
+                    new_locator_entries.append([label, handle_id, index, cell_id])
+
+            self._open_hdf.append(input_hdf)
+            keep_file_open = True
+            self.handle_list.append(
+                input_hdf.get(self.IMAGE_DATACONTAINTER_NAME)
+            )  # add new dataset to list of datasets
+            self.data_locator.extend(new_locator_entries)
 
         except (FileNotFoundError, KeyError, OSError) as e:
             print(f"Error: {e}")
             return
+        finally:
+            if input_hdf is not None and not keep_file_open:
+                input_hdf.close()
 
     def _add_dataset(
         self,

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -101,7 +101,7 @@ class _HDF5SingleCellDataset(Dataset):
             if file is not None:
                 try:
                     file.close()
-                except Exception:
+                except (OSError, RuntimeError, ValueError):
                     continue
         self._open_hdf.clear()
 
@@ -114,7 +114,7 @@ class _HDF5SingleCellDataset(Dataset):
     def __del__(self) -> None:
         try:
             self.close()
-        except Exception:
+        except (AttributeError, OSError, RuntimeError, ValueError):
             pass
 
     def _add_hdf_to_index(
@@ -632,7 +632,7 @@ class _H5ScSingleCellDataset(Dataset):
         for file in self._open_hdf:
             try:
                 file.close()
-            except Exception:
+            except (OSError, RuntimeError, ValueError):
                 continue
         self._open_hdf.clear()
         self.handle_list.clear()
@@ -646,7 +646,7 @@ class _H5ScSingleCellDataset(Dataset):
     def __del__(self) -> None:
         try:
             self.close()
-        except Exception:
+        except (AttributeError, OSError, RuntimeError, ValueError):
             pass
 
     def _add_hdf_to_index(

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -181,7 +181,11 @@ class _HDF5SingleCellDataset(Dataset):
                 assert label_column is not None, "Label column must be provided if read_label is set to True."
 
                 # get the column containing the labelling
-                label_col = input_hdf.get("single_cell_index_labelled").asstr()[:, label_column]
+                labelled_index = input_hdf.get("single_cell_index_labelled").asstr()
+                if index_list != [None]:
+                    label_col = labelled_index[index_list, label_column]
+                else:
+                    label_col = labelled_index[:, label_column]
 
                 # Older datasets may store missing labels as empty strings.
                 if len(label_col[label_col == ""]) > 0:
@@ -414,9 +418,6 @@ class _HDF5SingleCellDataset(Dataset):
         if self.transform:
             t = self.transform(t)  # apply transformation
 
-        if self.label_column_transform is not None:
-            label = self.label_column_transform(label)
-
         label = float(label)  # ensure its a numeric dtype
 
         if self.return_id:
@@ -541,7 +542,10 @@ class LabelledHDF5SingleCellDataset(_HDF5SingleCellDataset):
         self.label_column_transform = label_column_transform
         self.read_labels_from_dataset = True
 
-        self._add_all_datasets(read_label_from_dataset=self.read_labels_from_dataset)
+        self._add_all_datasets(
+            read_label_from_dataset=self.read_labels_from_dataset,
+            label_column_transform=self.label_column_transform,
+        )
         self.stats()
 
 
@@ -933,8 +937,6 @@ class _H5ScSingleCellDataset(Dataset):
         if self.transform:
             t = self.transform(t)  # apply transformation
 
-        if self.label_column_transform is not None:
-            label = self.label_column_transform(label)
         label = float(label)  # ensure its a numeric dtype
 
         if self.return_id:
@@ -1051,5 +1053,8 @@ class LabelledH5ScSingleCellDataset(_H5ScSingleCellDataset):
         self.label_column_transform = label_column_transform
         self.read_labels_from_dataset = True
 
-        self._add_all_datasets(read_label_from_dataset=self.read_labels_from_dataset)
+        self._add_all_datasets(
+            read_label_from_dataset=self.read_labels_from_dataset,
+            label_column_transform=self.label_column_transform,
+        )
         self.stats()

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -34,6 +34,7 @@ class _HDF5SingleCellDataset(Dataset):
     """
 
     HDF_FILETYPES = ["hdf", "hf", "h5", "hdf5"]  # supported hdf5 filetypes
+    _CLOSED_MESSAGE = "Dataset has been closed and cannot be reused."
 
     def __init__(
         self,
@@ -79,14 +80,20 @@ class _HDF5SingleCellDataset(Dataset):
         self.paths: list[str] = []
         self._open_hdf: dict[str, h5py.File | None] = {}
         self.data_locator: list[list[int]] = []
+        self._closed = False
 
         self.bulk_labels: list[int] | None = None
         self.label_column: int | None = None
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError(self._CLOSED_MESSAGE)
 
     def get_hdf(self, path: str) -> h5py.File:
         """
         Retrieve (or lazily create) a *process-local* file handle.
         """
+        self._ensure_open()
         file = self._open_hdf.get(path)
 
         if file is None:  # first call in this process
@@ -97,6 +104,9 @@ class _HDF5SingleCellDataset(Dataset):
 
     def close(self) -> None:
         """Close all opened HDF5 file handles."""
+        if self._closed:
+            return
+
         for file in self._open_hdf.values():
             if file is not None:
                 try:
@@ -104,6 +114,7 @@ class _HDF5SingleCellDataset(Dataset):
                 except (OSError, RuntimeError, ValueError):
                     continue
         self._open_hdf.clear()
+        self._closed = True
 
     def __enter__(self):
         return self
@@ -367,6 +378,7 @@ class _HDF5SingleCellDataset(Dataset):
         self, idx: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor]:
         """get item from dataset with the specified index `idx`"""
+        self._ensure_open()
 
         if torch.is_tensor(idx):
             idx = idx.tolist()  # convert tensor to list
@@ -579,6 +591,7 @@ class _H5ScSingleCellDataset(Dataset):
 
     IMAGE_DATACONTAINTER_NAME = IMAGE_DATACONTAINER_NAME
     INDEX_DATACONTAINER_NAME = INDEX_DATACONTAINER_NAME
+    _CLOSED_MESSAGE = "Dataset has been closed and cannot be reused."
 
     def __init__(
         self,
@@ -623,12 +636,20 @@ class _H5ScSingleCellDataset(Dataset):
         self.handle_list: list[Any] = []
         self._open_hdf: list[h5py.File] = []
         self.data_locator: list[list[int]] = []
+        self._closed = False
 
         self.bulk_labels: list[int] | None = None
         self.label_column: str | None = None
 
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError(self._CLOSED_MESSAGE)
+
     def close(self) -> None:
         """Close all opened HDF5 file handles."""
+        if self._closed:
+            return
+
         for file in self._open_hdf:
             try:
                 file.close()
@@ -636,6 +657,7 @@ class _H5ScSingleCellDataset(Dataset):
                 continue
         self._open_hdf.clear()
         self.handle_list.clear()
+        self._closed = True
 
     def __enter__(self):
         return self
@@ -904,6 +926,7 @@ class _H5ScSingleCellDataset(Dataset):
         self, idx: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor]:
         """get item from dataset with the specified index `idx`"""
+        self._ensure_open()
 
         if torch.is_tensor(idx):
             idx = idx.tolist()  # convert tensor to list

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -12,6 +12,7 @@ from scportrait.pipeline._utils.constants import IMAGE_DATACONTAINER_NAME, INDEX
 
 
 def _check_type_input_list(var):
+    """Return `True` when `var` is an iterable of iterables of integers."""
     return isinstance(var, Iterable) and all(
         isinstance(sublist, Iterable) and all(isinstance(item, int) for item in sublist) for sublist in var
     )
@@ -135,9 +136,7 @@ class _HDF5SingleCellDataset(Dataset):
         label_column_transform=None,
         read_label: bool = False,
     ):
-        """
-        Adds single cell data from the hdf5 file located at `path` with the specified `current_label` to the index.
-        """
+        """Add single-cell data from `path` to the dataset index."""
 
         # check to ensure that HDF5 file exists
         if not os.path.exists(path):
@@ -173,7 +172,7 @@ class _HDF5SingleCellDataset(Dataset):
                     f"Selected channels are out of bounds. Maximum available channelid is {max_channels}."
                 )
 
-            # add connection to singe cell datasets
+            # Add the path for later lazy file access in `__getitem__`.
             handle_id = len(self.paths)
             self.paths.append(path)  # add path to new dataset to list of paths
 
@@ -184,7 +183,7 @@ class _HDF5SingleCellDataset(Dataset):
                 # get the column containing the labelling
                 label_col = input_hdf.get("single_cell_index_labelled").asstr()[:, label_column]
 
-                # dirty fix that we have some old datasets that have empty strings instead of nan
+                # Older datasets may store missing labels as empty strings.
                 if len(label_col[label_col == ""]) > 0:
                     Warning(
                         "Empty strings found in label column. Replacing with nan. Please check your single-cell dataset."
@@ -261,16 +260,13 @@ class _HDF5SingleCellDataset(Dataset):
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
     ) -> None:
-        """
-        iterates over all files and folders in the directory provided by path and adds all found hdf5 files to the index.
-        Subfolders are recursively scanned.
+        """Recursively scan `path` and add matching HDF5 files to the dataset index.
 
         Args:
-            path: directory that should be searched for HDF5 files
-            label: label that should be attached to all cells found in any HDF5 files
-            label_col: column in the HDF5 file that should be used to read single-cell labels
-            levels_left: how many subfolder levels should be recurisively scanned for additional files
-            current_index_list: List of indices to select from the dataset. If set to None all cells are taken, by default None
+            path: Directory to search for HDF5 files.
+            levels_left: Remaining directory depth to scan recursively.
+            current_index_list: Indices to select from the dataset, if any.
+            read_label_from_dataset: Whether labels should be read from each dataset file.
         """
 
         # iterates over all files and folders in a directory
@@ -353,7 +349,7 @@ class _HDF5SingleCellDataset(Dataset):
                     current_index_list=current_index_list,
                 )
 
-    def stats(self, detailed: bool = False):  # print dataset statistics
+    def stats(self, detailed: bool = False):
         """Print dataset statistics.
 
         Args:
@@ -368,13 +364,13 @@ class _HDF5SingleCellDataset(Dataset):
                 print(f"single cell records with label {label} : {labels.count(label)}")
 
     def __len__(self) -> int:
-        """get number of elements contained in the dataset"""
+        """Return the number of indexed cells."""
         return len(self.data_locator)
 
     def __getitem__(
         self, idx: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor]:
-        """get item from dataset with the specified index `idx`"""
+        """Return the item at `idx`."""
         self._ensure_open()
 
         if torch.is_tensor(idx):
@@ -435,40 +431,17 @@ class _HDF5SingleCellDataset(Dataset):
 
 
 class HDF5SingleCellDataset(_HDF5SingleCellDataset):
-    """
-    Dataset reader for scPortraits single cell datasets stored in HDF5 files.
-
-    This class provides a convenient interface for scPortrait formatted hdf5 files containing single cell datasets. It supports loading data
-    from multiple hdf5 files within specified directories, applying transformations on the data, and returning
-    the required information, such as label or id, along with the single cell data.
-
-    It is compatible with the PyTorch DataLoader and can be used to load single cell data for training and evaluation.
-
-    Args:
-        dir_list: List of paths where the HDF5 files are stored. Supports specifying a path to a specific HDF5 file or a directory containing multiple HDF5 files.
-        dir_labels: List of bulk labels applied to all cells within each dataset in `dir_list`.
-        index_list: List of indices to select from the dataset. If `None`, all cells are included. Default is `None`.
-        select_channel: Specific channel or list of channels to retrieve from the data. Default is `None`, which returns all channels.
-            This is more efficient than performing selection via a transform function as the data is never read in the first place.
-        transform: User-defined function to apply transformations to the data. Default is `None`.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to keep this as `True`, otherwise
-            you can no longer identify the source cell returning a specific result.
-        max_level: Maximum number of directory levels to search for HDF5 files within the provided paths. Default is `5`.
+    """Dataset reader for scPortrait single-cell datasets stored in HDF5 files.
 
     Examples:
-
         .. code-block:: python
 
-            hdf5_data = HDF5SingleCellDataset(
-                dir_list=["path/to/data/data1.hdf5", "path/to/data/data2.hdf5"],
+            dataset = HDF5SingleCellDataset(
+                dir_list=["path/to/data1.hdf5", "path/to/data2.hdf5"],
                 dir_labels=[0, 1],
-                transform=None,
                 return_id=True,
             )
-
-            print(len(hdf5_data))  # Output: 2000
-
+            image, label, cell_id = dataset[0]
     """
 
     def __init__(
@@ -481,6 +454,17 @@ class HDF5SingleCellDataset(_HDF5SingleCellDataset):
         return_id: bool = True,
         select_channel: int | list[int] | None = None,
     ):
+        """Initialize a dataset with per-file labels stored outside the HDF5 payload.
+
+        Args:
+            dir_list: Paths to HDF5 files or directories containing HDF5 files.
+            dir_labels: Bulk labels applied to all cells from each entry in `dir_list`.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            transform: Optional transform applied to each returned tensor.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+            return_id: Whether to return the unique cell id together with the cell data.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+        """
         super().__init__(
             dir_list=dir_list,
             index_list=index_list,
@@ -502,42 +486,17 @@ class HDF5SingleCellDataset(_HDF5SingleCellDataset):
 
 
 class LabelledHDF5SingleCellDataset(_HDF5SingleCellDataset):
-    """
-    Dataset reader for scPortraits single cell datasets stored in HDF5 files. Single-cell labels are read directly from the HDF5 file.
-
-    This class provides an interface for scPortrait-formatted HDF5 files containing single-cell datasets. It supports loading data
-    from multiple HDF5 files within specified directories, applying transformations, and returning relevant information such as labels or IDs along with the single-cell data.
-
-    It is compatible with the PyTorch DataLoader and can be used to load single cell data for training and evaluation.
-
-    Args:
-        dir_list: List of paths where the HDF5 files are stored. Supports specifying a path to a specific HDF5 file or a directory containing multiple HDF5 files.
-        label_column: Index of the column from `single_cell_index_labelled` from which single-cell labels should be read.
-        label_dtype: Data type to which the read labels should be converted.
-        label_column_transform: Optional function to apply a mathematical transformation to the read labels.
-            For example, if the labels are stored as seconds in the HDF5 dataset, set this value to `lambda x: x / 3600` to return labels in hours.
-        index_list: List of indices to select from the dataset. If `None`, all cells are included. Default is `None`.
-        select_channel: Specific channel or list of channels to retrieve from the data. Default is `None`, which returns all channels.
-            This is more efficient than performing selection via a transform function as the data is never read in the first place.
-        transform: Optional user-defined function to apply transformations to the data. Default is `None`.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to set this to `True`, otherwise
-            you can no longer identify the source cell returning a specific result.
-        max_level: Maximum number of directory levels to search for HDF5 files within the provided paths. Default is `5`.
+    """Dataset reader for HDF5 single-cell datasets with labels stored in the file.
 
     Examples:
-
         .. code-block:: python
 
-            hdf5_data = HDF5SingleCellDataset(
-                dir_list=["path/to/data/data1.hdf5", "path/to/data/data2.hdf5"],
-                dir_labels=[0, 1],
-                transform=None,
-                return_id=True,
+            dataset = LabelledHDF5SingleCellDataset(
+                dir_list=["path/to/data.hdf5"],
+                label_colum=0,
+                label_dtype=float,
             )
-
-            print(len(hdf5_data))  # Output: 2000
-
+            image, label, cell_id = dataset[0]
     """
 
     def __init__(
@@ -552,6 +511,19 @@ class LabelledHDF5SingleCellDataset(_HDF5SingleCellDataset):
         return_id: bool = True,
         select_channel: list[int] | None | int = None,
     ):
+        """Initialize a dataset that reads per-cell labels from each HDF5 file.
+
+        Args:
+            dir_list: Paths to HDF5 files or directories containing HDF5 files.
+            label_colum: Column index in `single_cell_index_labelled` used as the label source.
+            label_dtype: Type used to convert the loaded labels.
+            label_column_transform: Optional transform applied to labels after loading.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            transform: Optional transform applied to each returned tensor.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+            return_id: Whether to return the unique cell id together with the cell data.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+        """
         super().__init__(
             dir_list=dir_list,
             index_list=index_list,  # list of indices to select from the index
@@ -677,9 +649,7 @@ class _H5ScSingleCellDataset(Dataset):
         label_column_transform=None,
         read_label: bool = False,
     ):
-        """
-        Adds single cell data from the hdf5 file located at `path` with the specified `current_label` to the index.
-        """
+        """Add single-cell data from `path` to the dataset index."""
 
         # check to ensure that HDF5 file exists
         if not os.path.exists(path):
@@ -809,16 +779,13 @@ class _H5ScSingleCellDataset(Dataset):
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
     ) -> None:
-        """
-        iterates over all files and folders in the directory provided by path and adds all found hdf5 files to the index.
-        Subfolders are recursively scanned.
+        """Recursively scan `path` and add matching HDF5 files to the dataset index.
 
         Args:
-            path: directory that should be searched for HDF5 files
-            label: label that should be attached to all cells found in any HDF5 files
-            label_col: column in the HDF5 file that should be used to read single-cell labels
-            levels_left: how many subfolder levels should be recurisively scanned for additional files
-            current_index_list: List of indices to select from the dataset. If set to None all cells are taken, by default None
+            path: Directory to search for HDF5 files.
+            levels_left: Remaining directory depth to scan recursively.
+            current_index_list: Indices to select from the dataset, if any.
+            read_label_from_dataset: Whether labels should be read from each dataset file.
         """
 
         # iterates over all files and folders in a directory
@@ -901,7 +868,7 @@ class _H5ScSingleCellDataset(Dataset):
                     current_index_list=current_index_list,
                 )
 
-    def stats(self, detailed: bool = False):  # print dataset statistics
+    def stats(self, detailed: bool = False):
         """Print dataset statistics.
 
         Args:
@@ -916,13 +883,13 @@ class _H5ScSingleCellDataset(Dataset):
                 print(f"single cell records with label {label} : {labels.count(label)}")
 
     def __len__(self) -> int:
-        """get number of elements contained in the dataset"""
+        """Return the number of indexed cells."""
         return len(self.data_locator)
 
     def __getitem__(
         self, idx: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor]:
-        """get item from dataset with the specified index `idx`"""
+        """Return the item at `idx`."""
         self._ensure_open()
 
         if torch.is_tensor(idx):
@@ -979,50 +946,17 @@ class _H5ScSingleCellDataset(Dataset):
 
 
 class H5ScSingleCellDataset(_H5ScSingleCellDataset):
-    """
-    Dataset reader for scPortraits single cell datasets stored in HDF5 files.
-
-    This class provides a convenient interface for scPortrait formatted hdf5 files containing single cell datasets. It supports loading data
-    from multiple hdf5 files within specified directories, applying transformations on the data, and returning
-    the required information, such as label or id, along with the single cell data.
-
-    It is compatible with the PyTorch DataLoader and can be used to load single cell data for training and evaluation.
-
-    Args:
-        dir_list: List of paths where the HDF5 files are stored. Supports specifying a path to a specific HDF5 file or a directory containing multiple HDF5 files.
-        dir_labels: List of bulk labels applied to all cells within each dataset in `dir_list`.
-        index_list: List of indices to select from the dataset. If `None`, all cells are included. Default is `None`.
-        select_channel: Specific channel or list of channels to retrieve from the data. Default is `None`, which returns all channels.
-            This is more efficient than performing selection via a transform function as the data is never read in the first place.
-        transform: User-defined function to apply transformations to the data. Default is `None`.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `False`.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to set this to `True`, otherwise
-            you can no longer identify the source cell returning a specific result.
-        max_level (int, optional):
-            Maximum number of directory levels to search for HDF5 files within the provided paths. Default is `5`.
-
-    Methods:
-        stats():
-            Prints dataset statistics, including the total count and count per label.
-        __len__():
-            Returns the total number of single cells in the dataset.
-        __getitem__(idx):
-            Retrieves the data, label, and optionally an ID or fake ID for the single cell at index `idx`.
+    """Dataset reader for scPortrait single-cell datasets stored in H5SC or H5AD files.
 
     Examples:
-
         .. code-block:: python
 
-            hdf5_data = HH5ScSingleCellDataset(
-                dir_list=["path/to/data/data1.hdf5", "path/to/data/data2.hdf5"],
-                dir_labels=[0, 1],
-                transform=None,
+            dataset = H5ScSingleCellDataset(
+                dir_list=["path/to/data.h5sc"],
+                dir_labels=[1],
                 return_id=True,
             )
-
-            print(len(hdf5_data))  # Output: 2000
-
+            image, label, cell_id = dataset[0]
     """
 
     def __init__(
@@ -1035,6 +969,17 @@ class H5ScSingleCellDataset(_H5ScSingleCellDataset):
         return_id: bool = True,
         select_channel: int | list[int] | None = None,
     ):
+        """Initialize a dataset with per-file labels stored outside the H5SC payload.
+
+        Args:
+            dir_list: Paths to H5SC/H5AD files or directories containing those files.
+            dir_labels: Bulk labels applied to all cells from each entry in `dir_list`.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            transform: Optional transform applied to each returned tensor.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+            return_id: Whether to return the unique cell id together with the cell data.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+        """
         super().__init__(
             dir_list=dir_list,
             index_list=index_list,
@@ -1052,48 +997,16 @@ class H5ScSingleCellDataset(_H5ScSingleCellDataset):
 
 
 class LabelledH5ScSingleCellDataset(_H5ScSingleCellDataset):
-    """
-    Dataset reader for scPortraits single cell datasets stored in HDF5 files. Single-cell labels are read directly from the HDF5 file.
-
-    This class provides an interface for scPortrait-formatted HDF5 files containing single-cell datasets. It supports loading data
-    from multiple HDF5 files within specified directories, applying transformations, and returning relevant information such as labels or IDs along with the single-cell data.
-
-    It is compatible with the PyTorch DataLoader and can be used to load single cell data for training and evaluation.
-
-    Args:
-        dir_list: List of paths where the HDF5 files are stored. Supports specifying a path to a specific HDF5 file or a directory containing multiple HDF5 files.
-        label_column: Index of the column from `single_cell_index_labelled` from which single-cell labels should be read.
-        label_column_transform: Optional function to apply a mathematical transformation to the read labels.
-            For example, if the labels are stored as seconds in the HDF5 dataset, set this value to `lambda x: x / 3600` to return labels in hours.
-        index_list: List of indices to select from the dataset. If `None`, all cells are included. Default is `None`.
-        select_channel: Specific channel or list of channels to retrieve from the data. Default is `None`, which returns all channels.
-            This is more efficient than performing selection via a transform function as the data is never read in the first place.
-        transform: Optional user-defined function to apply transformations to the data. Default is `None`.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to set this to `True`, otherwise
-            you can no longer identify the source cell returning a specific result.
-        max_level: Maximum number of directory levels to search for HDF5 files within the provided paths. Default is `5`.
-
-    Methods:
-        stats():
-            Prints dataset statistics, including the total count and count per label.
-        __len__():
-            Returns the total number of single cells in the dataset.
-        __getitem__(idx):
-            Retrieves the data, label, and optionally a unique ID for the single cell at index `idx`.
+    """Dataset reader for H5SC/H5AD single-cell datasets with labels stored in the file.
 
     Examples:
-
         .. code-block:: python
 
-            hdf5_data = HDF5SingleCellDataset(
-                dir_list=["path/to/data/data1.hdf5", "path/to/data/data2.hdf5"],
-                dir_labels=[0, 1],
-                transform=None,
-                return_id=True,
+            dataset = LabelledH5ScSingleCellDataset(
+                dir_list=["path/to/data.h5sc"],
+                label_colum="cell_type",
             )
-
-            print(len(hdf5_data))  # Output: 2000
+            image, label, cell_id = dataset[0]
     """
 
     def __init__(
@@ -1107,6 +1020,18 @@ class LabelledH5ScSingleCellDataset(_H5ScSingleCellDataset):
         return_id: bool = True,
         select_channel: list[int] | None | int = None,
     ):
+        """Initialize a dataset that reads per-cell labels from each H5SC or H5AD file.
+
+        Args:
+            dir_list: Paths to H5SC/H5AD files or directories containing those files.
+            label_colum: Column name in `obs` used as the label source.
+            label_column_transform: Optional transform applied to labels after loading.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            transform: Optional transform applied to each returned tensor.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+            return_id: Whether to return the unique cell id together with the cell data.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+        """
         super().__init__(
             dir_list=dir_list,
             index_list=index_list,  # list of indices to select from the index

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Callable, Iterable
+from pathlib import PosixPath
 from typing import Any
 
 import h5py
@@ -16,22 +17,8 @@ def _check_type_input_list(var):
     )
 
 
-from pathlib import PosixPath
-
-
 class _HDF5SingleCellDataset(Dataset):
-    """Base class with shared methods for loading scPortrait single cell datasets stored in HDF5 files.
-
-    Args:
-        dir_list: List of path(s) where the hdf5 files are stored. Supports specifying a path to a specific hdf5 file or directory containing hdf5 files.
-        index_list: List of cell indices to select from the dataset. If set to None all cells are taken. Default is None.
-        select_channel: Specify a specific channel or selection of channels to select from the data. Default is None, which returns all channels. Using this operation is more efficient than if this selection occurs via a passed transform.
-        transform: An optional user-defined function to apply transformations to the data. Default is None.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to set this to `True`,
-            otherwise you can no longer identify the source cell returning a specific result.
-        max_level: Maximum levels of directory to search for hdf5 files in the passed paths. Default is 5.
-    """
+    """Base class for loading scPortrait single-cell datasets stored in HDF5 files."""
 
     HDF_FILETYPES = ["hdf", "hf", "h5", "hdf5"]  # supported hdf5 filetypes
     _CLOSED_MESSAGE = "Dataset has been closed and cannot be reused."
@@ -45,7 +32,16 @@ class _HDF5SingleCellDataset(Dataset):
         return_id: bool = True,
         max_level: int = 5,
     ):
-        """ """
+        """Initialize the dataset index and runtime state.
+
+        Args:
+            dir_list: Paths to HDF5 files or directories containing HDF5 files.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+            transform: Optional transform applied to each returned tensor.
+            return_id: Whether to return the unique cell id together with the cell data.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+        """
         self.dir_list = dir_list
 
         if isinstance(self.dir_list[0], PosixPath):
@@ -86,6 +82,7 @@ class _HDF5SingleCellDataset(Dataset):
         self.label_column: int | None = None
 
     def _ensure_open(self) -> None:
+        """Raise if the dataset has been explicitly closed."""
         if self._closed:
             raise RuntimeError(self._CLOSED_MESSAGE)
 
@@ -103,7 +100,7 @@ class _HDF5SingleCellDataset(Dataset):
         return file
 
     def close(self) -> None:
-        """Close all opened HDF5 file handles."""
+        """Close open HDF5 handles and permanently disable further data access."""
         if self._closed:
             return
 
@@ -574,18 +571,7 @@ class LabelledHDF5SingleCellDataset(_HDF5SingleCellDataset):
 
 
 class _H5ScSingleCellDataset(Dataset):
-    """Base class with shared methods for loading scPortrait single cell datasets stored in scPortraits AnnData files.
-
-    Args:
-        dir_list: List of path(s) to the single-cell datasets. Supports specifying a path to a specific hd5c file or directory containing hd5c files.
-        index_list: List of cell indices to select from the dataset. If set to None all cells are taken. Default is None.
-        select_channel: Specify a specific channel or selection of channels to select from the data. Default is None, which returns all channels. Using this operation is more efficient than if this selection occurs via a passed transform.
-        transform: An optional user-defined function to apply transformations to the data. Default is None.
-        return_id: Whether to return the unique cell-id of the cell along with the data. Default is `True`.
-            For training purposes this can be set to `False`, but for dataset inference it is generally recommended to set this to `True`,
-            otherwise you can no longer identify the source cell returning a specific result.
-        max_level: Maximum levels of directory to search for hdf5 files in the passed paths. Default is 5.
-    """
+    """Base class for loading scPortrait single-cell datasets stored in AnnData-backed HDF5 files."""
 
     HDF_FILETYPES = ["h5sc", "h5ad"]  # supported filetypes
 
@@ -602,6 +588,16 @@ class _H5ScSingleCellDataset(Dataset):
         return_id: bool = True,
         max_level: int = 5,
     ):
+        """Initialize the dataset index and runtime state.
+
+        Args:
+            dir_list: Paths to H5SC/H5AD files or directories containing those files.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+            transform: Optional transform applied to each returned tensor.
+            return_id: Whether to return the unique cell id together with the cell data.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+        """
         self.dir_list = dir_list
 
         if isinstance(self.dir_list[0], PosixPath):
@@ -642,11 +638,12 @@ class _H5ScSingleCellDataset(Dataset):
         self.label_column: str | None = None
 
     def _ensure_open(self) -> None:
+        """Raise if the dataset has been explicitly closed."""
         if self._closed:
             raise RuntimeError(self._CLOSED_MESSAGE)
 
     def close(self) -> None:
-        """Close all opened HDF5 file handles."""
+        """Close open HDF5 handles and permanently disable further data access."""
         if self._closed:
             return
 

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -221,7 +221,7 @@ class _HDF5SingleCellDataset(Dataset):
         self,
         path: str,
         current_index_list: list[int],
-        id: int,
+        dataset_label_index: int,
         read_label_from_dataset: bool,
     ):
         """Adds a dataset to the index."""
@@ -246,7 +246,7 @@ class _HDF5SingleCellDataset(Dataset):
             self._add_hdf_to_index(
                 path=path,
                 index_list=current_index_list,
-                label=self.bulk_labels[id],
+                label=self.bulk_labels[dataset_label_index],
                 label_column=None,
                 dtype_label_column=None,
                 label_column_transform=None,
@@ -257,6 +257,7 @@ class _HDF5SingleCellDataset(Dataset):
         self,
         path: str,
         levels_left: int,
+        dataset_label_index: int,
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
     ) -> None:
@@ -282,14 +283,14 @@ class _HDF5SingleCellDataset(Dataset):
 
             current_level_files = [name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))]
 
-            for i, file in enumerate(current_level_files):
+            for _i, file in enumerate(current_level_files):
                 filetype = file.split(".")[-1]
 
                 if filetype in self.HDF_FILETYPES:
                     self._add_dataset(
-                        path=file,
+                        path=os.path.join(path, file),
                         current_index_list=current_index_list,
-                        id=i,
+                        dataset_label_index=dataset_label_index,
                         read_label_from_dataset=read_label_from_dataset,
                     )
 
@@ -298,6 +299,7 @@ class _HDF5SingleCellDataset(Dataset):
                 self._scan_directory(
                     subdirectory,
                     levels_left - 1,
+                    dataset_label_index,
                     current_index_list,
                     read_label_from_dataset,
                 )
@@ -337,7 +339,7 @@ class _HDF5SingleCellDataset(Dataset):
                 self._add_dataset(
                     path=directory,
                     current_index_list=current_index_list,
-                    id=i,
+                    dataset_label_index=i,
                     read_label_from_dataset=read_label_from_dataset,
                 )
 
@@ -346,6 +348,7 @@ class _HDF5SingleCellDataset(Dataset):
                 self._scan_directory(
                     path,
                     self.max_level,
+                    i,
                     current_index_list=current_index_list,
                 )
 
@@ -742,7 +745,7 @@ class _H5ScSingleCellDataset(Dataset):
         self,
         path: str,
         current_index_list: list[int],
-        id: int,
+        dataset_label_index: int,
         read_label_from_dataset: bool,
     ):
         """Adds a dataset to the index."""
@@ -766,7 +769,7 @@ class _H5ScSingleCellDataset(Dataset):
             self._add_hdf_to_index(
                 path=path,
                 index_list=current_index_list,
-                label=self.bulk_labels[id],
+                label=self.bulk_labels[dataset_label_index],
                 label_column=None,
                 label_column_transform=None,
                 read_label=False,
@@ -776,6 +779,7 @@ class _H5ScSingleCellDataset(Dataset):
         self,
         path: str,
         levels_left: int,
+        dataset_label_index: int,
         current_index_list: list[int] | None = None,
         read_label_from_dataset: bool = False,
     ) -> None:
@@ -801,14 +805,14 @@ class _H5ScSingleCellDataset(Dataset):
 
             current_level_files = [name for name in os.listdir(path) if os.path.isfile(os.path.join(path, name))]
 
-            for i, file in enumerate(current_level_files):
+            for _i, file in enumerate(current_level_files):
                 filetype = file.split(".")[-1]
 
                 if filetype in self.HDF_FILETYPES:
                     self._add_dataset(
-                        path=file,
+                        path=os.path.join(path, file),
                         current_index_list=current_index_list,
-                        id=i,
+                        dataset_label_index=dataset_label_index,
                         read_label_from_dataset=read_label_from_dataset,
                     )
 
@@ -817,6 +821,7 @@ class _H5ScSingleCellDataset(Dataset):
                 self._scan_directory(
                     subdirectory,
                     levels_left - 1,
+                    dataset_label_index,
                     current_index_list,
                     read_label_from_dataset,
                 )
@@ -856,7 +861,7 @@ class _H5ScSingleCellDataset(Dataset):
                 self._add_dataset(
                     path=directory,
                     current_index_list=current_index_list,
-                    id=i,
+                    dataset_label_index=i,
                     read_label_from_dataset=read_label_from_dataset,
                 )
 
@@ -865,6 +870,7 @@ class _H5ScSingleCellDataset(Dataset):
                 self._scan_directory(
                     path,
                     self.max_level,
+                    i,
                     current_index_list=current_index_list,
                 )
 

--- a/src/scportrait/tools/ml/datasets.py
+++ b/src/scportrait/tools/ml/datasets.py
@@ -36,7 +36,16 @@ class _HDF5SingleCellDataset(Dataset):
         return_id: bool = True,
         max_level: int = 5,
     ):
-        """ """
+        """Initialize the dataset index and runtime state.
+
+        Args:
+            dir_list: Paths to HDF5 files or directories containing HDF5 files.
+            index_list: Per-input lists of cell indices to include. If `None`, all cells are used.
+            select_channel: Channel index or indices to load from each cell image. If `None`, all channels are used.
+            transform: Optional transform applied to each returned tensor.
+            return_id: Whether to return the unique cell id together with the cell data.
+            max_level: Maximum directory depth to scan when an entry in `dir_list` is a directory.
+        """
         self.dir_list = [normalize_path(path) for path in dir_list]
 
         # ensure select_channel is always a list
@@ -65,8 +74,8 @@ class _HDF5SingleCellDataset(Dataset):
         # check reading of an image element and ensure that the selected channels are valid
 
         # initialize placeholders to store dataset information
-        self.paths: list[str] = []
-        self._open_hdf: dict[str, h5py.File | None] = {}
+        self.paths: list[Path] = []
+        self._open_hdf: dict[Path, h5py.File | None] = {}
         self.data_locator: list[list[int]] = []
         self._closed = False
 
@@ -78,12 +87,13 @@ class _HDF5SingleCellDataset(Dataset):
         if self._closed:
             raise RuntimeError(self._CLOSED_MESSAGE)
 
-    def get_hdf(self, path: str) -> h5py.File:
+    def get_hdf(self, path: str | os.PathLike[str]) -> h5py.File:
         """
         Retrieve (or lazily create) a *process-local* file handle.
         """
         self._ensure_open()
-        normalized_path = os.fspath(path)
+
+        normalized_path = normalize_path(path)
         file = self._open_hdf.get(normalized_path)
 
         if file is None:  # first call in this process
@@ -167,7 +177,7 @@ class _HDF5SingleCellDataset(Dataset):
 
             # Add the path for later lazy file access in `__getitem__`.
             handle_id = len(self.paths)
-            self.paths.append(os.fspath(normalized_path))  # add path to new dataset to list of paths
+            self.paths.append(normalized_path)  # add path to new dataset to list of paths
 
             # add single-cell labelling
             if read_label:
@@ -322,7 +332,7 @@ class _HDF5SingleCellDataset(Dataset):
 
         # scan all directories provided
         for i, directory in enumerate(self.dir_list):
-            path = directory.resolve()
+            path = directory
             current_index_list = self.index_list[i]
 
             # get current label
@@ -841,7 +851,7 @@ class _H5ScSingleCellDataset(Dataset):
 
         # scan all directories provided
         for i, directory in enumerate(self.dir_list):
-            path = directory.resolve()
+            path = directory
             current_index_list = self.index_list[i]
 
             # get current label

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -20,42 +20,65 @@ from scportrait.tools.ml.datasets import (
 )  # Adjust import path as needed
 
 
-@pytest.fixture
-def temp_hdf5_file():
-    """Create a temporary HDF5 file for testing."""
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
-    with h5py.File(temp_file.name, "w") as f:
+def _create_hdf5_test_file(path: str) -> None:
+    with h5py.File(path, "w") as f:
         rng = np.random.default_rng()
         f.create_dataset("single_cell_data", data=rng.random((100, 3, 128, 128)))
         f.create_dataset("single_cell_index", data=np.array([[i, i] for i in range(100)]))
         labelled_index = np.char.encode(np.array([[i, i] for i in range(100)]).astype(str))
         dt = h5py.special_dtype(vlen=str)
         f.create_dataset("single_cell_index_labelled", data=labelled_index, chunks=None, dtype=dt)
+
+
+def _create_h5sc_test_file(path: str) -> None:
+    with h5py.File(path, "w") as f:
+        rng = np.random.default_rng()
+        f.attrs["encoding-type"] = "anndata"
+        f.create_dataset("obs/scportrait_cell_id", data=np.arange(100, dtype=np.uint64))  # cell ids
+        f.create_dataset("obs/pseudo_label", data=np.arange(100, dtype=np.uint64))  # add a pseudo label
+        f.create_dataset("obsm/single_cell_images", data=rng.random((100, 5, 64, 64)))  # single-cell images
+
+
+@pytest.fixture
+def temp_hdf5_file():
+    """Create a temporary HDF5 file for testing."""
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
+    temp_file.close()
+    _create_hdf5_test_file(temp_file.name)
     yield temp_file.name  # Provide the file path to the test
-    os.remove(temp_file.name)  # Cleanup after the test
+    if os.path.exists(temp_file.name):
+        os.remove(temp_file.name)  # Cleanup after the test
 
 
 @pytest.fixture
 def hdf5_dataset(temp_hdf5_file):
     """Fixture for an HDF5SingleCellDataset instance."""
-    return HDF5SingleCellDataset(
+    dataset = HDF5SingleCellDataset(
         dir_list=[temp_hdf5_file],
         dir_labels=[0],
         transform=None,
         return_id=True,
     )
+    try:
+        yield dataset
+    finally:
+        dataset.close()
 
 
 @pytest.fixture
 def labelled_hdf5_dataset(temp_hdf5_file):
     """Fixture for a LabelledHDF5SingleCellDataset instance."""
-    return LabelledHDF5SingleCellDataset(
+    dataset = LabelledHDF5SingleCellDataset(
         dir_list=[temp_hdf5_file],
         label_colum=0,
         label_dtype=int,
         label_column_transform=None,
         return_id=True,
     )
+    try:
+        yield dataset
+    finally:
+        dataset.close()
 
 
 def test_dataset_initialization(hdf5_dataset):
@@ -86,11 +109,11 @@ def test_get_item_out_of_bounds(hdf5_dataset):
 
 def test_get_item_without_id(temp_hdf5_file):
     """Test retrieving an item when `return_id=False`."""
-    dataset_no_id = HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=False)
-    item = dataset_no_id[0]
-    assert len(item) == 2  # (data, label)
-    assert isinstance(item[0], torch.Tensor)
-    assert item[1].ndim == 0  # scalar
+    with HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=False) as dataset_no_id:
+        item = dataset_no_id[0]
+        assert len(item) == 2  # (data, label)
+        assert isinstance(item[0], torch.Tensor)
+        assert item[1].ndim == 0  # scalar
 
 
 def test_labelled_dataset_initialization(labelled_hdf5_dataset):
@@ -137,36 +160,59 @@ def test_index_list_subset(temp_hdf5_file):
     """Test that only specified indices are loaded via index_list."""
     # Only use first 10 entries
     index_list = [list(range(10))]
-    dataset = HDF5SingleCellDataset(
+    with HDF5SingleCellDataset(
         dir_list=[temp_hdf5_file],
         dir_labels=[1],
         index_list=index_list,
         return_id=True,
-    )
-    assert len(dataset) == 10
-    for i in range(len(dataset)):
-        item = dataset[i]
-        assert isinstance(item[0], torch.Tensor)
-        assert item[1].ndim == 0  # scalar
-        assert item[2].ndim == 0  # scalar
+    ) as dataset:
+        assert len(dataset) == 10
+        for i in range(len(dataset)):
+            item = dataset[i]
+            assert isinstance(item[0], torch.Tensor)
+            assert item[1].ndim == 0  # scalar
+            assert item[2].ndim == 0  # scalar
 
 
 def test_labelled_index_list_subset(temp_hdf5_file):
     """Test that only specified indices are loaded for labelled dataset via index_list."""
     index_list = [list(range(5, 15))]  # 10 elements
-    dataset = LabelledHDF5SingleCellDataset(
+    with LabelledHDF5SingleCellDataset(
         dir_list=[temp_hdf5_file],
         label_colum=0,
         label_dtype=int,
         index_list=index_list,
         return_id=True,
-    )
-    assert len(dataset) == 10
-    for i in range(len(dataset)):
-        item = dataset[i]
-        assert isinstance(item[0], torch.Tensor)
-        assert item[1].ndim == 0  # scalar
-        assert item[2].ndim == 0  # scalar
+    ) as dataset:
+        assert len(dataset) == 10
+        for i in range(len(dataset)):
+            item = dataset[i]
+            assert isinstance(item[0], torch.Tensor)
+            assert item[1].ndim == 0  # scalar
+            assert item[2].ndim == 0  # scalar
+
+
+def test_hdf5_close_is_idempotent(temp_hdf5_file):
+    dataset = HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=True)
+    _ = dataset[0]
+    dataset.close()
+    dataset.close()
+    assert dataset._open_hdf == {}
+
+
+def test_hdf5_context_manager_releases_file():
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
+    temp_file.close()
+    _create_hdf5_test_file(temp_file.name)
+
+    try:
+        with HDF5SingleCellDataset(dir_list=[temp_file.name], dir_labels=[0], return_id=True) as dataset:
+            _ = dataset[0]
+        os.remove(temp_file.name)
+        assert not os.path.exists(temp_file.name)
+    finally:
+        if os.path.exists(temp_file.name):
+            os.remove(temp_file.name)
 
 
 # ### test h5sc
@@ -176,14 +222,11 @@ def test_labelled_index_list_subset(temp_hdf5_file):
 def temp_h5sc_file():
     """Create a temporary H5SC (AnnData-like) HDF5 file for testing."""
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".h5sc")
-    with h5py.File(temp_file.name, "w") as f:
-        rng = np.random.default_rng()
-        f.attrs["encoding-type"] = "anndata"
-        f.create_dataset("obs/scportrait_cell_id", data=np.arange(100, dtype=np.uint64))  # cell ids
-        f.create_dataset("obs/pseudo_label", data=np.arange(100, dtype=np.uint64))  # add a pseudo label
-        f.create_dataset("obsm/single_cell_images", data=rng.random((100, 5, 64, 64)))  # single-cell images
+    temp_file.close()
+    _create_h5sc_test_file(temp_file.name)
     yield temp_file.name
-    os.remove(temp_file.name)
+    if os.path.exists(temp_file.name):
+        os.remove(temp_file.name)
 
 
 from scportrait.tools.ml.datasets import (
@@ -193,50 +236,33 @@ from scportrait.tools.ml.datasets import (
 
 
 def test_h5sc_dataset_initialization(temp_h5sc_file):
-    dataset = H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1])
-    assert isinstance(dataset, H5ScSingleCellDataset)
-    assert len(dataset) == 100
+    with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
+        assert isinstance(dataset, H5ScSingleCellDataset)
+        assert len(dataset) == 100
 
 
 def test_labelled_h5sc_dataset_initialization(temp_h5sc_file):
-    dataset = LabelledH5ScSingleCellDataset(
+    with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
-    )
-    assert isinstance(dataset, LabelledH5ScSingleCellDataset)
-    assert len(dataset) == 100
+    ) as dataset:
+        assert isinstance(dataset, LabelledH5ScSingleCellDataset)
+        assert len(dataset) == 100
 
 
 def test_h5sc_get_item(temp_h5sc_file):
-    dataset = H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1])
-    item = dataset[0]
-    assert len(item) == 3
+    with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
+        item = dataset[0]
+        assert len(item) == 3
 
-    img, label, idx = item
-    assert isinstance(img, torch.Tensor)
+        img, label, idx = item
+        assert isinstance(img, torch.Tensor)
 
 
 def test_labelled_h5sc_get_item(temp_h5sc_file):
-    dataset = LabelledH5ScSingleCellDataset(
+    with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
-    )
-    item = dataset[0]
-    assert len(item) == 3
-
-    img, label, idx = item
-    assert isinstance(img, torch.Tensor)
-    assert label.ndim == 0  # scalar
-    assert idx.ndim == 0  # scalar
-
-
-def test_h5sc_index_list_subset(temp_h5sc_file):
-    dataset = H5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file],
-        dir_labels=[0],
-        index_list=[[0, 1, 2, 3, 4]],
-    )
-    assert len(dataset) == 5
-    for i in range(len(dataset)):
-        item = dataset[i]
+    ) as dataset:
+        item = dataset[0]
         assert len(item) == 3
 
         img, label, idx = item
@@ -245,18 +271,59 @@ def test_h5sc_index_list_subset(temp_h5sc_file):
         assert idx.ndim == 0  # scalar
 
 
+def test_h5sc_index_list_subset(temp_h5sc_file):
+    with H5ScSingleCellDataset(
+        dir_list=[temp_h5sc_file],
+        dir_labels=[0],
+        index_list=[[0, 1, 2, 3, 4]],
+    ) as dataset:
+        assert len(dataset) == 5
+        for i in range(len(dataset)):
+            item = dataset[i]
+            assert len(item) == 3
+
+            img, label, idx = item
+            assert isinstance(img, torch.Tensor)
+            assert label.ndim == 0  # scalar
+            assert idx.ndim == 0  # scalar
+
+
 def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
-    dataset = LabelledH5ScSingleCellDataset(
+    with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file],
         label_colum="pseudo_label",
         index_list=[[10, 11, 12]],
         label_column_transform=None,
-    )
-    assert len(dataset) == 3
-    for i in range(len(dataset)):
-        item = dataset[i]
-        assert len(item) == 3
-        img, label, idx = item
-        assert isinstance(img, torch.Tensor)
-        assert label.ndim == 0  # scalar
-        assert idx.ndim == 0  # scalar
+    ) as dataset:
+        assert len(dataset) == 3
+        for i in range(len(dataset)):
+            item = dataset[i]
+            assert len(item) == 3
+            img, label, idx = item
+            assert isinstance(img, torch.Tensor)
+            assert label.ndim == 0  # scalar
+            assert idx.ndim == 0  # scalar
+
+
+def test_h5sc_close_is_idempotent(temp_h5sc_file):
+    dataset = H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1])
+    _ = dataset[0]
+    dataset.close()
+    dataset.close()
+    assert dataset.handle_list == []
+    assert dataset._open_hdf == []
+
+
+def test_h5sc_context_manager_releases_file():
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".h5sc")
+    temp_file.close()
+    _create_h5sc_test_file(temp_file.name)
+
+    try:
+        with H5ScSingleCellDataset(dir_list=[temp_file.name], dir_labels=[1]) as dataset:
+            _ = dataset[0]
+        os.remove(temp_file.name)
+        assert not os.path.exists(temp_file.name)
+    finally:
+        if os.path.exists(temp_file.name):
+            os.remove(temp_file.name)

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -197,7 +197,10 @@ def test_hdf5_close_is_idempotent(temp_hdf5_file):
     _ = dataset[0]
     dataset.close()
     dataset.close()
+    assert dataset._closed is True
     assert dataset._open_hdf == {}
+    with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
+        dataset[0]
 
 
 def test_hdf5_context_manager_releases_file():
@@ -208,8 +211,10 @@ def test_hdf5_context_manager_releases_file():
     try:
         with HDF5SingleCellDataset(dir_list=[temp_file.name], dir_labels=[0], return_id=True) as dataset:
             _ = dataset[0]
-        os.remove(temp_file.name)
-        assert not os.path.exists(temp_file.name)
+        assert dataset._closed is True
+        assert dataset._open_hdf == {}
+        with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
+            dataset[0]
     finally:
         if os.path.exists(temp_file.name):
             os.remove(temp_file.name)
@@ -310,8 +315,11 @@ def test_h5sc_close_is_idempotent(temp_h5sc_file):
     _ = dataset[0]
     dataset.close()
     dataset.close()
+    assert dataset._closed is True
     assert dataset.handle_list == []
     assert dataset._open_hdf == []
+    with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
+        dataset[0]
 
 
 def test_h5sc_context_manager_releases_file():
@@ -322,8 +330,11 @@ def test_h5sc_context_manager_releases_file():
     try:
         with H5ScSingleCellDataset(dir_list=[temp_file.name], dir_labels=[1]) as dataset:
             _ = dataset[0]
-        os.remove(temp_file.name)
-        assert not os.path.exists(temp_file.name)
+        assert dataset._closed is True
+        assert dataset.handle_list == []
+        assert dataset._open_hdf == []
+        with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
+            dataset[0]
     finally:
         if os.path.exists(temp_file.name):
             os.remove(temp_file.name)

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -5,6 +5,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import h5py
@@ -128,6 +129,13 @@ def test_get_item_without_id(temp_hdf5_file):
         assert len(item) == 2  # (data, label)
         assert isinstance(item[0], torch.Tensor)
         assert item[1].ndim == 0  # scalar
+
+
+def test_hdf5_dataset_accepts_pathlike_inputs(temp_hdf5_file):
+    """Test that HDF5 datasets accept pathlib.Path inputs."""
+    with HDF5SingleCellDataset(dir_list=[Path(temp_hdf5_file)], dir_labels=[0], return_id=True) as dataset:
+        item = dataset[0]
+        assert len(item) == 3
 
 
 def test_labelled_dataset_initialization(labelled_hdf5_dataset):
@@ -323,6 +331,13 @@ def test_h5sc_get_item(temp_h5sc_file):
 
         img, label, idx = item
         assert isinstance(img, torch.Tensor)
+
+
+def test_h5sc_dataset_accepts_pathlike_inputs(temp_h5sc_file):
+    """Test that H5SC datasets accept pathlib.Path inputs."""
+    with H5ScSingleCellDataset(dir_list=[Path(temp_h5sc_file)], dir_labels=[1]) as dataset:
+        item = dataset[0]
+        assert len(item) == 3
 
 
 def test_labelled_h5sc_get_item(temp_h5sc_file):

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -42,6 +42,18 @@ def _create_h5sc_test_file(path: str) -> None:
 
 
 @pytest.fixture
+def temp_hdf5_dir():
+    """Create a temporary directory containing multiple HDF5 files for testing."""
+    temp_dir = tempfile.TemporaryDirectory()
+    _create_hdf5_test_file(os.path.join(temp_dir.name, "part_a.hdf5"))
+    _create_hdf5_test_file(os.path.join(temp_dir.name, "part_b.hdf5"))
+    try:
+        yield temp_dir.name
+    finally:
+        temp_dir.cleanup()
+
+
+@pytest.fixture
 def temp_hdf5_file():
     """Create a temporary HDF5 file for testing."""
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
@@ -194,6 +206,19 @@ def test_labelled_index_list_subset(temp_hdf5_file):
             assert item[2].ndim == 0  # scalar
 
 
+def test_hdf5_directory_scan_uses_full_paths_and_directory_label(temp_hdf5_dir):
+    """Test that directory inputs load all HDF5 files with the correct shared label."""
+    with HDF5SingleCellDataset(dir_list=[temp_hdf5_dir], dir_labels=[7], return_id=True) as dataset:
+        assert len(dataset) == 200
+        assert all(os.path.dirname(path) == temp_hdf5_dir for path in dataset.paths)
+        assert len(dataset.paths) == 2
+
+        first_item = dataset[0]
+        last_item = dataset[len(dataset) - 1]
+        assert float(first_item[1]) == 7.0
+        assert float(last_item[1]) == 7.0
+
+
 def test_hdf5_close_is_idempotent(temp_hdf5_file):
     """Test that closing an HDF5 dataset is idempotent and terminal."""
     dataset = HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=True)
@@ -233,6 +258,18 @@ def temp_h5sc_file():
     yield temp_file.name
     if os.path.exists(temp_file.name):
         os.remove(temp_file.name)
+
+
+@pytest.fixture
+def temp_h5sc_dir():
+    """Create a temporary directory containing multiple H5SC files for testing."""
+    temp_dir = tempfile.TemporaryDirectory()
+    _create_h5sc_test_file(os.path.join(temp_dir.name, "part_a.h5sc"))
+    _create_h5sc_test_file(os.path.join(temp_dir.name, "part_b.h5sc"))
+    try:
+        yield temp_dir.name
+    finally:
+        temp_dir.cleanup()
 
 
 def test_h5sc_dataset_initialization(temp_h5sc_file):
@@ -309,6 +346,18 @@ def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
             assert isinstance(img, torch.Tensor)
             assert label.ndim == 0  # scalar
             assert idx.ndim == 0  # scalar
+
+
+def test_h5sc_directory_scan_uses_full_paths_and_directory_label(temp_h5sc_dir):
+    """Test that directory inputs load all H5SC files with the correct shared label."""
+    with H5ScSingleCellDataset(dir_list=[temp_h5sc_dir], dir_labels=[3], return_id=True) as dataset:
+        assert len(dataset) == 200
+        assert len(dataset.handle_list) == 2
+
+        first_item = dataset[0]
+        last_item = dataset[len(dataset) - 1]
+        assert float(first_item[1]) == 3.0
+        assert float(last_item[1]) == 3.0
 
 
 def test_h5sc_close_is_idempotent(temp_h5sc_file):

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -13,11 +13,13 @@ import pytest
 import torch
 
 from scportrait.tools.ml.datasets import (
+    H5ScSingleCellDataset,
     HDF5SingleCellDataset,
+    LabelledH5ScSingleCellDataset,
     LabelledHDF5SingleCellDataset,
     _check_type_input_list,
     _HDF5SingleCellDataset,
-)  # Adjust import path as needed
+)
 
 
 def _create_hdf5_test_file(path: str) -> None:
@@ -193,6 +195,7 @@ def test_labelled_index_list_subset(temp_hdf5_file):
 
 
 def test_hdf5_close_is_idempotent(temp_hdf5_file):
+    """Test that closing an HDF5 dataset is idempotent and terminal."""
     dataset = HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=True)
     _ = dataset[0]
     dataset.close()
@@ -204,6 +207,7 @@ def test_hdf5_close_is_idempotent(temp_hdf5_file):
 
 
 def test_hdf5_context_manager_releases_file():
+    """Test that the HDF5 dataset context manager closes the dataset on exit."""
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
     temp_file.close()
     _create_hdf5_test_file(temp_file.name)
@@ -220,9 +224,6 @@ def test_hdf5_context_manager_releases_file():
             os.remove(temp_file.name)
 
 
-# ### test h5sc
-
-
 @pytest.fixture
 def temp_h5sc_file():
     """Create a temporary H5SC (AnnData-like) HDF5 file for testing."""
@@ -234,19 +235,15 @@ def temp_h5sc_file():
         os.remove(temp_file.name)
 
 
-from scportrait.tools.ml.datasets import (
-    H5ScSingleCellDataset,
-    LabelledH5ScSingleCellDataset,
-)
-
-
 def test_h5sc_dataset_initialization(temp_h5sc_file):
+    """Test H5SC dataset initialization."""
     with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
         assert isinstance(dataset, H5ScSingleCellDataset)
         assert len(dataset) == 100
 
 
 def test_labelled_h5sc_dataset_initialization(temp_h5sc_file):
+    """Test labelled H5SC dataset initialization."""
     with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
     ) as dataset:
@@ -255,6 +252,7 @@ def test_labelled_h5sc_dataset_initialization(temp_h5sc_file):
 
 
 def test_h5sc_get_item(temp_h5sc_file):
+    """Test retrieving an item from an H5SC dataset."""
     with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
         item = dataset[0]
         assert len(item) == 3
@@ -264,6 +262,7 @@ def test_h5sc_get_item(temp_h5sc_file):
 
 
 def test_labelled_h5sc_get_item(temp_h5sc_file):
+    """Test retrieving an item from a labelled H5SC dataset."""
     with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
     ) as dataset:
@@ -277,6 +276,7 @@ def test_labelled_h5sc_get_item(temp_h5sc_file):
 
 
 def test_h5sc_index_list_subset(temp_h5sc_file):
+    """Test that only specified indices are loaded for H5SC datasets."""
     with H5ScSingleCellDataset(
         dir_list=[temp_h5sc_file],
         dir_labels=[0],
@@ -294,6 +294,7 @@ def test_h5sc_index_list_subset(temp_h5sc_file):
 
 
 def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
+    """Test that only specified indices are loaded for labelled H5SC datasets."""
     with LabelledH5ScSingleCellDataset(
         dir_list=[temp_h5sc_file],
         label_colum="pseudo_label",
@@ -311,6 +312,7 @@ def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
 
 
 def test_h5sc_close_is_idempotent(temp_h5sc_file):
+    """Test that closing an H5SC dataset is idempotent and terminal."""
     dataset = H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1])
     _ = dataset[0]
     dataset.close()
@@ -323,6 +325,7 @@ def test_h5sc_close_is_idempotent(temp_h5sc_file):
 
 
 def test_h5sc_context_manager_releases_file():
+    """Test that the H5SC dataset context manager closes the dataset on exit."""
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".h5sc")
     temp_file.close()
     _create_h5sc_test_file(temp_file.name)

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -65,97 +65,95 @@ def temp_hdf5_file():
         os.remove(temp_file.name)  # Cleanup after the test
 
 
-@pytest.fixture
-def hdf5_dataset(temp_hdf5_file):
-    """Fixture for an HDF5SingleCellDataset instance."""
-    dataset = HDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        dir_labels=[0],
-        transform=None,
-        return_id=True,
-    )
-    try:
-        yield dataset
-    finally:
-        dataset.close()
+_BASIC_CASES = [
+    pytest.param("temp_hdf5_file", HDF5SingleCellDataset, {"dir_labels": [0]}, id="hdf5"),
+    pytest.param("temp_h5sc_file", H5ScSingleCellDataset, {"dir_labels": [1]}, id="h5sc"),
+]
+
+_LABELLED_CASES = [
+    pytest.param(
+        "temp_hdf5_file",
+        LabelledHDF5SingleCellDataset,
+        {"label_colum": 0, "label_dtype": int},
+        id="labelled-hdf5",
+    ),
+    pytest.param(
+        "temp_h5sc_file",
+        LabelledH5ScSingleCellDataset,
+        {"label_colum": "pseudo_label"},
+        id="labelled-h5sc",
+    ),
+]
+
+_DIRECTORY_CASES = [
+    pytest.param("temp_hdf5_dir", HDF5SingleCellDataset, {"dir_labels": [7]}, 7.0, 200, id="hdf5"),
+    pytest.param("temp_h5sc_dir", H5ScSingleCellDataset, {"dir_labels": [3]}, 3.0, 200, id="h5sc"),
+]
 
 
-@pytest.fixture
-def labelled_hdf5_dataset(temp_hdf5_file):
-    """Fixture for a LabelledHDF5SingleCellDataset instance."""
-    dataset = LabelledHDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        label_colum=0,
-        label_dtype=int,
-        label_column_transform=None,
-        return_id=True,
-    )
-    try:
-        yield dataset
-    finally:
-        dataset.close()
-
-
-def test_dataset_initialization(hdf5_dataset):
-    """Test dataset initializes correctly."""
-    assert isinstance(hdf5_dataset, HDF5SingleCellDataset)
-    assert len(hdf5_dataset.dir_list) == 1
-
-
-def test_dataset_length(hdf5_dataset):
-    """Test dataset length matches expected value."""
-    assert len(hdf5_dataset) == 100
-
-
-def test_get_item(hdf5_dataset):
-    """Test retrieving an item from the dataset."""
-    item = hdf5_dataset[0]
-    assert len(item) == 3  # (data, label, id)
+def _assert_item_shapes(item: tuple[torch.Tensor, ...], expected_len: int) -> None:
+    assert len(item) == expected_len
     assert isinstance(item[0], torch.Tensor)
-    assert item[1].ndim == 0  # scalar
-    assert item[2].ndim == 0  # scalar
+
+    for value in item[1:]:
+        assert value.ndim == 0
 
 
-def test_get_item_out_of_bounds(hdf5_dataset):
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_dataset_initialization(request, fixture_name, dataset_cls, init_kwargs):
+    """Test basic datasets initialize correctly."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs) as dataset:
+        assert isinstance(dataset, dataset_cls)
+        assert len(dataset.dir_list) == 1
+        assert len(dataset) == 100
+
+
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_get_item(request, fixture_name, dataset_cls, init_kwargs):
+    """Test retrieving an item from a basic dataset."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs) as dataset:
+        _assert_item_shapes(dataset[0], 3)
+
+
+def test_get_item_out_of_bounds(temp_hdf5_file):
     """Test index out of range error handling."""
-    with pytest.raises(IndexError):
-        _ = hdf5_dataset[200]
+    with HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=True) as dataset:
+        with pytest.raises(IndexError):
+            _ = dataset[200]
+
+
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_dataset_accepts_pathlike_inputs(request, fixture_name, dataset_cls, init_kwargs):
+    """Test that datasets accept pathlib.Path inputs."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[Path(dataset_path)], return_id=True, **init_kwargs) as dataset:
+        _assert_item_shapes(dataset[0], 3)
 
 
 def test_get_item_without_id(temp_hdf5_file):
     """Test retrieving an item when `return_id=False`."""
-    with HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=False) as dataset_no_id:
-        item = dataset_no_id[0]
-        assert len(item) == 2  # (data, label)
-        assert isinstance(item[0], torch.Tensor)
-        assert item[1].ndim == 0  # scalar
+    with HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=False) as dataset:
+        _assert_item_shapes(dataset[0], 2)
 
 
-def test_hdf5_dataset_accepts_pathlike_inputs(temp_hdf5_file):
-    """Test that HDF5 datasets accept pathlib.Path inputs."""
-    with HDF5SingleCellDataset(dir_list=[Path(temp_hdf5_file)], dir_labels=[0], return_id=True) as dataset:
-        item = dataset[0]
-        assert len(item) == 3
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _LABELLED_CASES)
+def test_labelled_dataset_initialization(request, fixture_name, dataset_cls, init_kwargs):
+    """Test labelled datasets initialize correctly."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs) as dataset:
+        assert isinstance(dataset, dataset_cls)
+        assert len(dataset.dir_list) == 1
+        assert len(dataset) == 100
 
 
-def test_labelled_dataset_initialization(labelled_hdf5_dataset):
-    """Test labelled dataset initializes correctly."""
-    assert isinstance(labelled_hdf5_dataset, LabelledHDF5SingleCellDataset)
-    assert len(labelled_hdf5_dataset.dir_list) == 1
-
-
-def test_labelled_dataset_length(labelled_hdf5_dataset):
-    """Test labelled dataset length matches expected value."""
-    assert len(labelled_hdf5_dataset) == 100
-
-
-def test_labelled_get_item(labelled_hdf5_dataset):
-    """Test retrieving an item from the labelled dataset."""
-    item = labelled_hdf5_dataset[0]
-    assert len(item) == 3  # (data, label, id)
-    assert isinstance(item[0], torch.Tensor)
-    assert item[1].ndim == 0  # scalar
-    assert item[2].ndim == 0  # scalar
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _LABELLED_CASES)
+def test_labelled_get_item(request, fixture_name, dataset_cls, init_kwargs):
+    """Test retrieving an item from a labelled dataset."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs) as dataset:
+        _assert_item_shapes(dataset[0], 3)
 
 
 @pytest.mark.parametrize(
@@ -178,110 +176,125 @@ def test_add_hdf_to_index_file_not_found(mock_exists):
         dataset._add_hdf_to_index("nonexistent.hdf5")
 
 
-def test_index_list_subset(temp_hdf5_file):
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_index_list_subset(request, fixture_name, dataset_cls, init_kwargs):
     """Test that only specified indices are loaded via index_list."""
-    # Only use first 10 entries
-    index_list = [list(range(10))]
-    with HDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        dir_labels=[1],
-        index_list=index_list,
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(
+        dir_list=[dataset_path],
+        index_list=[[0, 1, 2, 3, 4]],
         return_id=True,
+        **init_kwargs,
     ) as dataset:
-        assert len(dataset) == 10
+        assert len(dataset) == 5
         for i in range(len(dataset)):
-            item = dataset[i]
-            assert isinstance(item[0], torch.Tensor)
-            assert item[1].ndim == 0  # scalar
-            assert item[2].ndim == 0  # scalar
+            _assert_item_shapes(dataset[i], 3)
 
 
-def test_labelled_index_list_subset(temp_hdf5_file):
-    """Test that only specified indices are loaded for labelled dataset via index_list."""
-    index_list = [list(range(5, 15))]  # 10 elements
-    with LabelledHDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        label_colum=0,
-        label_dtype=int,
-        index_list=index_list,
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _LABELLED_CASES)
+def test_labelled_index_list_subset(request, fixture_name, dataset_cls, init_kwargs):
+    """Test that only specified indices are loaded for labelled datasets via index_list."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(
+        dir_list=[dataset_path],
+        index_list=[[10, 11, 12]],
         return_id=True,
+        **init_kwargs,
     ) as dataset:
-        assert len(dataset) == 10
-        for i in range(len(dataset)):
-            item = dataset[i]
-            assert isinstance(item[0], torch.Tensor)
-            assert item[1].ndim == 0  # scalar
-            assert item[2].ndim == 0  # scalar
-
-
-def test_labelled_hdf5_subset_uses_selected_row_labels(temp_hdf5_file):
-    """Test that labelled HDF5 subsets read labels from the selected rows."""
-    with LabelledHDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        label_colum=0,
-        label_dtype=int,
-        index_list=[[5, 6, 7]],
-        return_id=True,
-    ) as dataset:
+        assert len(dataset) == 3
         labels = [int(dataset[i][1]) for i in range(len(dataset))]
-        assert labels == [5, 6, 7]
+        assert labels == [10, 11, 12]
+        for i in range(len(dataset)):
+            _assert_item_shapes(dataset[i], 3)
 
 
-def test_labelled_hdf5_label_transform_applied_once(temp_hdf5_file):
-    """Test that HDF5 label transforms are applied exactly once."""
-    with LabelledHDF5SingleCellDataset(
-        dir_list=[temp_hdf5_file],
-        label_colum=0,
-        label_dtype=float,
-        label_column_transform=lambda x: x / 10,
+@pytest.mark.parametrize(
+    ("fixture_name", "dataset_cls", "init_kwargs"),
+    [
+        pytest.param(
+            "temp_hdf5_file",
+            LabelledHDF5SingleCellDataset,
+            {"label_colum": 0, "label_dtype": float, "label_column_transform": lambda x: x / 10},
+            id="hdf5",
+        ),
+        pytest.param(
+            "temp_h5sc_file",
+            LabelledH5ScSingleCellDataset,
+            {"label_colum": "pseudo_label", "label_column_transform": lambda x: x / 10},
+            id="h5sc",
+        ),
+    ],
+)
+def test_label_transform_applied_once(request, fixture_name, dataset_cls, init_kwargs):
+    """Test that label transforms are applied exactly once."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(
+        dir_list=[dataset_path],
         index_list=[[10]],
         return_id=True,
+        **init_kwargs,
     ) as dataset:
-        item = dataset[0]
-        assert float(item[1]) == 1.0
+        assert float(dataset[0][1]) == 1.0
 
 
-def test_hdf5_directory_scan_uses_full_paths_and_directory_label(temp_hdf5_dir):
-    """Test that directory inputs load all HDF5 files with the correct shared label."""
-    with HDF5SingleCellDataset(dir_list=[temp_hdf5_dir], dir_labels=[7], return_id=True) as dataset:
-        assert len(dataset) == 200
-        assert all(os.path.dirname(path) == temp_hdf5_dir for path in dataset.paths)
-        assert len(dataset.paths) == 2
+@pytest.mark.parametrize(
+    ("fixture_name", "dataset_cls", "init_kwargs", "expected_label", "expected_len"),
+    _DIRECTORY_CASES,
+)
+def test_directory_scan_uses_full_paths_and_directory_label(
+    request, fixture_name, dataset_cls, init_kwargs, expected_label, expected_len
+):
+    """Test that directory inputs load all files with the correct shared label."""
+    dataset_dir = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_dir], return_id=True, **init_kwargs) as dataset:
+        assert len(dataset) == expected_len
 
-        first_item = dataset[0]
-        last_item = dataset[len(dataset) - 1]
-        assert float(first_item[1]) == 7.0
-        assert float(last_item[1]) == 7.0
+        if hasattr(dataset, "paths"):
+            assert all(os.path.dirname(path) == dataset_dir for path in dataset.paths)
+            assert len(dataset.paths) == 2
+        else:
+            assert len(dataset.handle_list) == 2
+
+        assert float(dataset[0][1]) == expected_label
+        assert float(dataset[len(dataset) - 1][1]) == expected_label
 
 
-def test_hdf5_close_is_idempotent(temp_hdf5_file):
-    """Test that closing an HDF5 dataset is idempotent and terminal."""
-    dataset = HDF5SingleCellDataset(dir_list=[temp_hdf5_file], dir_labels=[0], return_id=True)
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_close_is_idempotent(request, fixture_name, dataset_cls, init_kwargs):
+    """Test that closing a dataset is idempotent and terminal."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    dataset = dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs)
     _ = dataset[0]
     dataset.close()
     dataset.close()
+
     assert dataset._closed is True
-    assert dataset._open_hdf == {}
+    if hasattr(dataset, "paths"):
+        assert dataset._open_hdf == {}
+    else:
+        assert dataset.handle_list == []
+        assert dataset._open_hdf == []
+
     with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
         dataset[0]
 
 
-def test_hdf5_context_manager_releases_file():
-    """Test that the HDF5 dataset context manager closes the dataset on exit."""
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".hdf5")
-    temp_file.close()
-    _create_hdf5_test_file(temp_file.name)
+@pytest.mark.parametrize(("fixture_name", "dataset_cls", "init_kwargs"), _BASIC_CASES)
+def test_context_manager_releases_file(request, fixture_name, dataset_cls, init_kwargs):
+    """Test that dataset context managers close the dataset on exit."""
+    dataset_path = request.getfixturevalue(fixture_name)
+    with dataset_cls(dir_list=[dataset_path], return_id=True, **init_kwargs) as dataset:
+        _ = dataset[0]
 
-    try:
-        with HDF5SingleCellDataset(dir_list=[temp_file.name], dir_labels=[0], return_id=True) as dataset:
-            _ = dataset[0]
-        assert dataset._closed is True
+    assert dataset._closed is True
+    if hasattr(dataset, "paths"):
         assert dataset._open_hdf == {}
-        with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
-            dataset[0]
-    finally:
-        if os.path.exists(temp_file.name):
-            os.remove(temp_file.name)
+    else:
+        assert dataset.handle_list == []
+        assert dataset._open_hdf == []
+
+    with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
+        dataset[0]
 
 
 @pytest.fixture
@@ -305,143 +318,3 @@ def temp_h5sc_dir():
         yield temp_dir.name
     finally:
         temp_dir.cleanup()
-
-
-def test_h5sc_dataset_initialization(temp_h5sc_file):
-    """Test H5SC dataset initialization."""
-    with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
-        assert isinstance(dataset, H5ScSingleCellDataset)
-        assert len(dataset) == 100
-
-
-def test_labelled_h5sc_dataset_initialization(temp_h5sc_file):
-    """Test labelled H5SC dataset initialization."""
-    with LabelledH5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
-    ) as dataset:
-        assert isinstance(dataset, LabelledH5ScSingleCellDataset)
-        assert len(dataset) == 100
-
-
-def test_h5sc_get_item(temp_h5sc_file):
-    """Test retrieving an item from an H5SC dataset."""
-    with H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1]) as dataset:
-        item = dataset[0]
-        assert len(item) == 3
-
-        img, label, idx = item
-        assert isinstance(img, torch.Tensor)
-
-
-def test_h5sc_dataset_accepts_pathlike_inputs(temp_h5sc_file):
-    """Test that H5SC datasets accept pathlib.Path inputs."""
-    with H5ScSingleCellDataset(dir_list=[Path(temp_h5sc_file)], dir_labels=[1]) as dataset:
-        item = dataset[0]
-        assert len(item) == 3
-
-
-def test_labelled_h5sc_get_item(temp_h5sc_file):
-    """Test retrieving an item from a labelled H5SC dataset."""
-    with LabelledH5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file], label_colum="pseudo_label", label_column_transform=None
-    ) as dataset:
-        item = dataset[0]
-        assert len(item) == 3
-
-        img, label, idx = item
-        assert isinstance(img, torch.Tensor)
-        assert label.ndim == 0  # scalar
-        assert idx.ndim == 0  # scalar
-
-
-def test_h5sc_index_list_subset(temp_h5sc_file):
-    """Test that only specified indices are loaded for H5SC datasets."""
-    with H5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file],
-        dir_labels=[0],
-        index_list=[[0, 1, 2, 3, 4]],
-    ) as dataset:
-        assert len(dataset) == 5
-        for i in range(len(dataset)):
-            item = dataset[i]
-            assert len(item) == 3
-
-            img, label, idx = item
-            assert isinstance(img, torch.Tensor)
-            assert label.ndim == 0  # scalar
-            assert idx.ndim == 0  # scalar
-
-
-def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
-    """Test that only specified indices are loaded for labelled H5SC datasets."""
-    with LabelledH5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file],
-        label_colum="pseudo_label",
-        index_list=[[10, 11, 12]],
-        label_column_transform=None,
-    ) as dataset:
-        assert len(dataset) == 3
-        for i in range(len(dataset)):
-            item = dataset[i]
-            assert len(item) == 3
-            img, label, idx = item
-            assert isinstance(img, torch.Tensor)
-            assert label.ndim == 0  # scalar
-            assert idx.ndim == 0  # scalar
-
-
-def test_labelled_h5sc_label_transform_applied_once(temp_h5sc_file):
-    """Test that H5SC label transforms are applied exactly once."""
-    with LabelledH5ScSingleCellDataset(
-        dir_list=[temp_h5sc_file],
-        label_colum="pseudo_label",
-        label_column_transform=lambda x: x / 10,
-        index_list=[[10]],
-        return_id=True,
-    ) as dataset:
-        item = dataset[0]
-        assert float(item[1]) == 1.0
-
-
-def test_h5sc_directory_scan_uses_full_paths_and_directory_label(temp_h5sc_dir):
-    """Test that directory inputs load all H5SC files with the correct shared label."""
-    with H5ScSingleCellDataset(dir_list=[temp_h5sc_dir], dir_labels=[3], return_id=True) as dataset:
-        assert len(dataset) == 200
-        assert len(dataset.handle_list) == 2
-
-        first_item = dataset[0]
-        last_item = dataset[len(dataset) - 1]
-        assert float(first_item[1]) == 3.0
-        assert float(last_item[1]) == 3.0
-
-
-def test_h5sc_close_is_idempotent(temp_h5sc_file):
-    """Test that closing an H5SC dataset is idempotent and terminal."""
-    dataset = H5ScSingleCellDataset(dir_list=[temp_h5sc_file], dir_labels=[1])
-    _ = dataset[0]
-    dataset.close()
-    dataset.close()
-    assert dataset._closed is True
-    assert dataset.handle_list == []
-    assert dataset._open_hdf == []
-    with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
-        dataset[0]
-
-
-def test_h5sc_context_manager_releases_file():
-    """Test that the H5SC dataset context manager closes the dataset on exit."""
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".h5sc")
-    temp_file.close()
-    _create_h5sc_test_file(temp_file.name)
-
-    try:
-        with H5ScSingleCellDataset(dir_list=[temp_file.name], dir_labels=[1]) as dataset:
-            _ = dataset[0]
-        assert dataset._closed is True
-        assert dataset.handle_list == []
-        assert dataset._open_hdf == []
-        with pytest.raises(RuntimeError, match="Dataset has been closed and cannot be reused."):
-            dataset[0]
-    finally:
-        if os.path.exists(temp_file.name):
-            os.remove(temp_file.name)

--- a/tests/unit_tests/tools/ml/test_datasets.py
+++ b/tests/unit_tests/tools/ml/test_datasets.py
@@ -206,6 +206,33 @@ def test_labelled_index_list_subset(temp_hdf5_file):
             assert item[2].ndim == 0  # scalar
 
 
+def test_labelled_hdf5_subset_uses_selected_row_labels(temp_hdf5_file):
+    """Test that labelled HDF5 subsets read labels from the selected rows."""
+    with LabelledHDF5SingleCellDataset(
+        dir_list=[temp_hdf5_file],
+        label_colum=0,
+        label_dtype=int,
+        index_list=[[5, 6, 7]],
+        return_id=True,
+    ) as dataset:
+        labels = [int(dataset[i][1]) for i in range(len(dataset))]
+        assert labels == [5, 6, 7]
+
+
+def test_labelled_hdf5_label_transform_applied_once(temp_hdf5_file):
+    """Test that HDF5 label transforms are applied exactly once."""
+    with LabelledHDF5SingleCellDataset(
+        dir_list=[temp_hdf5_file],
+        label_colum=0,
+        label_dtype=float,
+        label_column_transform=lambda x: x / 10,
+        index_list=[[10]],
+        return_id=True,
+    ) as dataset:
+        item = dataset[0]
+        assert float(item[1]) == 1.0
+
+
 def test_hdf5_directory_scan_uses_full_paths_and_directory_label(temp_hdf5_dir):
     """Test that directory inputs load all HDF5 files with the correct shared label."""
     with HDF5SingleCellDataset(dir_list=[temp_hdf5_dir], dir_labels=[7], return_id=True) as dataset:
@@ -346,6 +373,19 @@ def test_labelled_h5sc_index_list_subset(temp_h5sc_file):
             assert isinstance(img, torch.Tensor)
             assert label.ndim == 0  # scalar
             assert idx.ndim == 0  # scalar
+
+
+def test_labelled_h5sc_label_transform_applied_once(temp_h5sc_file):
+    """Test that H5SC label transforms are applied exactly once."""
+    with LabelledH5ScSingleCellDataset(
+        dir_list=[temp_h5sc_file],
+        label_colum="pseudo_label",
+        label_column_transform=lambda x: x / 10,
+        index_list=[[10]],
+        return_id=True,
+    ) as dataset:
+        item = dataset[0]
+        assert float(item[1]) == 1.0
 
 
 def test_h5sc_directory_scan_uses_full_paths_and_directory_label(temp_h5sc_dir):


### PR DESCRIPTION
# Add close lifecycle for HDF5-backed ML dataset classes

This PR adds an explicit cleanup lifecycle for HDF5-backed ML dataset classes.

On Windows, several dataset tests failed during teardown because temporary `.hdf5` and `.h5sc` files were still open when the test fixtures tried to delete them. Windows prevents deletion of open files, so this exposed file handles that were not being released after dataset use.

## Problem

Several ML dataset tests failed on Windows with:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```

The affected tests included:

* `tests/unit_tests/tools/ml/test_datasets.py::test_dataset_initialization`
* `tests/unit_tests/tools/ml/test_datasets.py::test_dataset_length`
* `tests/unit_tests/tools/ml/test_datasets.py::test_get_item`
* `tests/unit_tests/tools/ml/test_datasets.py::test_get_item_out_of_bounds`
* `tests/unit_tests/tools/ml/test_datasets.py::test_get_item_without_id`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_dataset_initialization`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_dataset_length`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_get_item`
* `tests/unit_tests/tools/ml/test_datasets.py::test_index_list_subset`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_index_list_subset`
* `tests/unit_tests/tools/ml/test_datasets.py::test_h5sc_dataset_initialization`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_h5sc_dataset_initialization`
* `tests/unit_tests/tools/ml/test_datasets.py::test_h5sc_get_item`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_h5sc_get_item`
* `tests/unit_tests/tools/ml/test_datasets.py::test_h5sc_index_list_subset`
* `tests/unit_tests/tools/ml/test_datasets.py::test_labelled_h5sc_index_list_subset`

The tests themselves were able to run, but teardown failed because the temporary files remained locked.

## Root cause

The HDF5-backed dataset classes opened `.hdf5` / `.h5sc` files but did not provide a reliable way to close the underlying `h5py.File` handles.

This is especially visible on Windows because Windows does not allow open files to be deleted. On Linux/macOS, this kind of issue can be easier to miss because deleting open files is often allowed.

## Changes

This PR introduces explicit resource cleanup for the relevant dataset classes.

The changes include:

* adding a `close()` method to release internally opened HDF5 handles
* clearing internal handle caches after closing files
* making repeated `close()` calls safe
* adding context-manager support with `__enter__` and `__exit__`
* ensuring H5SC-backed paths also retain and close the owning `h5py.File`
* updating tests so temporary HDF5/H5SC files are released before fixture teardown

## Why this matters

This is **_more_** than a Windows test cleanup issue.

These dataset classes may be used in long-running training, featurisation, or batch-processing workflows. If file handles are not closed reliably, users can run into locked files, resource leaks, or hard-to-debug behaviour after repeated dataset creation.

Adding a clear close lifecycle makes the classes safer and easier to use.

## Testing

Tested locally on Windows with:

* Python 3.12.13
* pytest 9.0.3
* Conda environment: `scportrait312`

Relevant test command:

```
python -m pytest tests/unit_tests/tools/ml/test_datasets.py --disable-warnings
```

Expected result:

* all tests in `tests/unit_tests/tools/ml/test_datasets.py` pass
* temporary `.hdf5` files are deleted successfully during teardown
* temporary `.h5sc` files are deleted successfully during teardown

## Additional coverage

This PR also adds or updates tests to cover the cleanup lifecycle:

* calling `close()` releases backing file handles
* using the dataset in a context manager releases backing file handles on exit
* repeated `close()` calls are safe
* normal dataset operations such as `len(...)` and item access continue to work as before

## Notes

This PR is focused on resource management for HDF5-backed ML datasets. It should not change the public data access behaviour of the dataset classes, aside from adding a safer and more explicit cleanup API.
