### PR TITLE
Optional dependencies python support

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install package
         run: |

--- a/.github/workflows/unit_test_os_matrix_manual.yml
+++ b/.github/workflows/unit_test_os_matrix_manual.yml
@@ -1,0 +1,35 @@
+name: Perform Unit Tests OS Matrix Manual
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: ${{ matrix.os }} / Python 3.14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install package
+        run: |
+          pip install uv
+          uv pip install --system ".[tests]"
+
+      - name: Test with pytest
+        run: |
+          pytest tests/unit_tests --disable-warnings

--- a/.github/workflows/unit_test_python_matrix.yml
+++ b/.github/workflows/unit_test_python_matrix.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.14",] #don't re run 3.13 since it is already tested in the main workflow
 
     name: Python ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![GitHub Release](https://img.shields.io/github/v/release/mannlabs/scPortrait?logoColor=green&color=brightgreen)](https://github.com/MannLabs/scPortrait/releases)
-![Versions](https://img.shields.io/badge/python-3.10_%7C_3.11_%7C_3.12-brightgreen)
+![Versions](https://img.shields.io/badge/python-3.11_%7C_3.12_%7C_3.13_%7C_3.14-brightgreen)
 [![License](https://img.shields.io/badge/license-Apache-brightgreen)](https://github.com/MannLabs/scPortrait/blob/main/LICENSE)
 [![Docs](https://img.shields.io/website?url=https%3A%2F%2Fmannlabs.github.io/scPortrait/index.html)](https://mannlabs.github.io/scPortrait/index.html)
 [![Unit Tests](https://github.com/MannLabs/scPortrait/actions/workflows/unit_test.yml/badge.svg)](https://github.com/MannLabs/scPortrait/actions/workflows/unit_test.yml)
@@ -21,7 +21,7 @@ Please refer to our [documentation](https://mannlabs.github.io/scPortrait/), in 
 
 ## Installation from Github
 
-Check out the docs for [complete installation instructions](https://mannlabs.github.io/scPortrait/pages/installation.html). scPortrait currently supports Python 3.10, 3.11 and 3.12.
+Check out the docs for [complete installation instructions](https://mannlabs.github.io/scPortrait/pages/installation.html). scPortrait currently supports Python 3.11, 3.12, 3.13 and 3.14.
 
 To get started you can install scPortrait via pip:
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -42,3 +42,10 @@ To install the latest release of scPortrait:
 .. code::
 
    pip install scportrait
+
+Optional feature extras are available for dependencies that are only needed by specific workflows:
+
+.. code::
+
+   pip install "scportrait[segmentation]"  # scikit-fmm-backed segmentation helpers and workflows
+   pip install "scportrait[zstack]"        # extended depth-of-field z-stack compression

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ************
 
-We recommended installing the library within a separate conda environment running Python 3.11, 3.12, 3.13 or 3.14.
+We recommend installing the library within a separate conda environment running Python 3.11, 3.12, 3.13 or 3.14.
 
 .. code::
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ************
 
-We recommended installing the library within a separate conda environment running Python 3.10, 3.11 or 3.12.
+We recommended installing the library within a separate conda environment running Python 3.11, 3.12, 3.13 or 3.14.
 
 .. code::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,19 @@ classifiers = [
 dependencies = {file = ["requirements/requirements.txt"]}
 
 [tool.setuptools.dynamic.optional-dependencies]
+segmentation = {file = ["requirements/requirements_segmentation.txt"]}
+zstack = {file = ["requirements/requirements_zstack.txt"]}
 dev = {file = ["requirements/requirements_dev.txt"]}
-tests = {file = ["requirements/requirements_test.txt"]}
-docs = {file = ["requirements/requirements_docs.txt"]}
+tests = {file = [
+    "requirements/requirements_test.txt",
+    "requirements/requirements_segmentation.txt",
+    "requirements/requirements_zstack.txt",
+]}
+docs = {file = [
+    "requirements/requirements_docs.txt",
+    "requirements/requirements_segmentation.txt",
+    "requirements/requirements_zstack.txt",
+]}
 plotting = {file = ["requirements/requirements_plotting.txt"]}
 stitching = {file = ["requirements/requirements_stitching.txt"]}
 convnext = {file = ["requirements/requirements_convnext.txt"]}
@@ -48,7 +58,9 @@ all = {file = [
     "requirements/requirements_test.txt",
     "requirements/requirements_docs.txt",
     "requirements/requirements_plotting.txt",
+    "requirements/requirements_segmentation.txt",
     "requirements/requirements_stitching.txt",
+    "requirements/requirements_zstack.txt",
 ]}
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "scportrait"
 version = "1.7.1-dev0"
 description = "Computational framework to generate single cell datasets from raw microscopy images."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 keywords = ["single-cell", "image analysis", "spatial omics", "deep learning", "image representation"]
 dynamic = ["dependencies", "optional-dependencies"]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,6 +14,7 @@ py-lmd>=1.3.1
 requests
 filelock
 PyYAML
+deprecation
 
 spatialdata-plot>=0.2.14
 matplotlib
@@ -26,9 +27,7 @@ ome-zarr
 scipy
 scikit-image>=0.22.0
 scikit-learn
-mahotas
 
-scikit-fmm #WGA segmentation
 cellpose>=3.1.1,<4 #cellpose segmentation
 
 torch

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,10 +6,10 @@ pandas
 h5py
 alphabase
 anndata
-spatialdata>=0.3.0
+spatialdata>=0.7.3
 dask
 xarray
-pyarrow<22.0.0
+pyarrow
 py-lmd>=1.3.1
 requests
 filelock

--- a/requirements/requirements_segmentation.txt
+++ b/requirements/requirements_segmentation.txt
@@ -1,0 +1,1 @@
+scikit-fmm  # fast marching segmentation helpers and workflows

--- a/requirements/requirements_zstack.txt
+++ b/requirements/requirements_zstack.txt
@@ -1,0 +1,1 @@
+mahotas  # extended depth-of-field z-stack compression

--- a/src/scportrait/_utils/__init__.py
+++ b/src/scportrait/_utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility helpers for scPortrait."""
 
 from .deprecation import deprecated
+from .optional_dependencies import import_optional_dependency
 from .paths import normalize_path, path_suffix
 
-__all__ = ["deprecated", "normalize_path", "path_suffix"]
+__all__ = ["deprecated", "import_optional_dependency", "normalize_path", "path_suffix"]

--- a/src/scportrait/_utils/deprecation.py
+++ b/src/scportrait/_utils/deprecation.py
@@ -1,38 +1,5 @@
 """Helpers for deprecating public APIs."""
 
-from __future__ import annotations
+from deprecation import deprecated
 
-import functools
-import warnings
-from collections.abc import Callable
-from typing import TypeVar
-
-T = TypeVar("T", bound=Callable[..., object])
-
-try:
-    from deprecation import deprecated as _deprecated
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
-    _deprecated = None
-
-
-def deprecated(*args, **kwargs):
-    """Return a deprecation decorator.
-
-    If the optional `deprecation` dependency is installed, this proxies to
-    `deprecation.deprecated`. Otherwise it falls back to a lightweight wrapper
-    that emits a DeprecationWarning at call time.
-    """
-    if _deprecated is not None:
-        return _deprecated(*args, **kwargs)
-
-    details = kwargs.get("details", "This function is deprecated and will be removed in a future release.")
-
-    def _decorator(func: T) -> T:
-        @functools.wraps(func)
-        def _wrapped(*f_args, **f_kwargs):
-            warnings.warn(details, DeprecationWarning, stacklevel=2)
-            return func(*f_args, **f_kwargs)
-
-        return _wrapped  # type: ignore[return-value]
-
-    return _decorator
+__all__ = ["deprecated"]

--- a/src/scportrait/_utils/optional_dependencies.py
+++ b/src/scportrait/_utils/optional_dependencies.py
@@ -9,6 +9,14 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 
+def _is_missing_target_module(err: ModuleNotFoundError, module_name: str) -> bool:
+    """Return whether the missing module error refers to the requested dependency itself."""
+    missing_name = getattr(err, "name", None)
+    if missing_name is None:
+        return False
+    return missing_name == module_name or module_name.startswith(f"{missing_name}.")
+
+
 def import_optional_dependency(
     module_name: str,
     *,
@@ -22,7 +30,10 @@ def import_optional_dependency(
     """Import an optional dependency and raise a guided error when unavailable."""
     try:
         module = importlib.import_module(module_name)
-    except (ImportError, ModuleNotFoundError):
+    except ModuleNotFoundError as err:
+        if not _is_missing_target_module(err, module_name):
+            raise
+
         if not raise_on_missing:
             return None
 
@@ -35,7 +46,9 @@ def import_optional_dependency(
             if install_hint is not None:
                 error_message += f" Please install with `{install_hint}`."
 
-        raise ImportError(error_message) from None
+        raise ImportError(error_message) from err
+    except ImportError:
+        raise
 
     if attribute is None:
         return module

--- a/src/scportrait/_utils/optional_dependencies.py
+++ b/src/scportrait/_utils/optional_dependencies.py
@@ -1,0 +1,47 @@
+"""Helpers for importing optional dependencies with consistent error messages."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def import_optional_dependency(
+    module_name: str,
+    *,
+    attribute: str | None = None,
+    package_name: str | None = None,
+    feature: str | None = None,
+    install_hint: str | None = None,
+    error_message: str | None = None,
+    raise_on_missing: bool = True,
+) -> ModuleType | Any | None:
+    """Import an optional dependency and raise a guided error when unavailable."""
+    try:
+        module = importlib.import_module(module_name)
+    except (ImportError, ModuleNotFoundError):
+        if not raise_on_missing:
+            return None
+
+        if error_message is None:
+            dependency_name = package_name or module_name.split(".")[0]
+            error_message = f"{dependency_name} is required"
+            if feature is not None:
+                error_message += f" for {feature}"
+            error_message += "."
+            if install_hint is not None:
+                error_message += f" Please install with `{install_hint}`."
+
+        raise ImportError(error_message) from None
+
+    if attribute is None:
+        return module
+
+    try:
+        return getattr(module, attribute)
+    except AttributeError as err:
+        dependency_name = package_name or module_name
+        raise ImportError(f"{dependency_name} does not provide `{attribute}`.") from err

--- a/src/scportrait/pipeline/_utils/helper.py
+++ b/src/scportrait/pipeline/_utils/helper.py
@@ -3,6 +3,8 @@ from typing import TypeVar
 
 import yaml
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
+
 T = TypeVar("T")
 
 
@@ -50,10 +52,9 @@ def flatten(nested_list: list[list[T]]) -> list[T | tuple[T]]:
 
 def _check_for_spatialdata_plot() -> None:
     """Helper function to check if required package is installed"""
-    # check for spatialdata_plot
-    try:
-        import spatialdata_plot
-    except ImportError:
-        raise ImportError(
-            "Extended plotting capabilities required. Please install with `pip install 'scportrait[plotting]'`."
-        ) from None
+    import_optional_dependency(
+        "spatialdata_plot",
+        feature="extended plotting capabilities",
+        install_hint="pip install 'scportrait[plotting]'",
+        error_message="Extended plotting capabilities required. Please install with `pip install 'scportrait[plotting]'`.",
+    )

--- a/src/scportrait/pipeline/_utils/segmentation.py
+++ b/src/scportrait/pipeline/_utils/segmentation.py
@@ -5,7 +5,6 @@ import warnings
 import matplotlib.pyplot as plt
 import numba as nb
 import numpy as np
-import skfmm
 from numba import njit, objmode, prange
 from numpy.typing import NDArray
 from scipy import ndimage
@@ -16,6 +15,7 @@ from skimage.morphology import dilation as sk_dilation
 from skimage.segmentation import watershed
 from skimage.transform import resize
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
 from scportrait.pipeline._utils.constants import DEFAULT_SEGMENTATION_DTYPE
 from scportrait.plotting._vis import plot_image_array
 
@@ -95,6 +95,12 @@ def _generate_labels_from_mask(
     Returns:
         Label array where each segment has unique label
     """
+    skfmm = import_optional_dependency(
+        "skfmm",
+        package_name="scikit-fmm",
+        feature="the fast-marching segmentation utilities and workflows",
+        install_hint="pip install 'scportrait[segmentation]'",
+    )
     distance = ndimage.distance_transform_edt(image_mask)
     peak_idx = peak_local_max(distance, min_distance=min_distance, footprint=disk(peak_footprint))
     local_maxi = np.zeros_like(image_mask, dtype=bool)

--- a/src/scportrait/pipeline/featurization.py
+++ b/src/scportrait/pipeline/featurization.py
@@ -19,6 +19,7 @@ from anndata import AnnData
 from spatialdata.models import TableModel
 from torchvision import transforms
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
 from scportrait.pipeline._base import ProcessingStep
 from scportrait.tools.ml.datasets import H5ScSingleCellDataset
 from scportrait.tools.ml.plmodels import MultilabelSupervisedModel
@@ -30,6 +31,15 @@ if TYPE_CHECKING:
 
 
 from dataclasses import dataclass
+
+
+def _import_transformers():
+    """Return the optional ``transformers`` module for ConvNeXt featurization."""
+    return import_optional_dependency(
+        "transformers",
+        feature="ConvNeXt featurization",
+        install_hint="pip install 'scportrait[convnext]'",
+    )
 
 
 @dataclass
@@ -1323,10 +1333,7 @@ class ConvNeXtFeaturizer(_FeaturizationBase):
             self._clean_log_file()
 
         # assert that the correct transformers version is installed
-        try:
-            import transformers
-        except ImportError:
-            raise ImportError("transformers is not installed. Please install it via pip install transformers") from None
+        _import_transformers()
 
         assert len(self.channel_selection) in [1, 3], "channel_selection should be either 1 or 3 channels"
 
@@ -1334,8 +1341,8 @@ class ConvNeXtFeaturizer(_FeaturizationBase):
         self.label = f"{self.LABEL}_{'_'.join(f'Ch{n}' for n in self.channel_selection)}"
 
     def _load_model(self):
-        # lazy imports
-        from transformers import ConvNextModel
+        transformers = _import_transformers()
+        ConvNextModel = transformers.ConvNextModel
 
         # silence warnings from transformers that are not relevant here
         # we do actually just want to load some of the weights to access the convnext features
@@ -1349,7 +1356,7 @@ class ConvNeXtFeaturizer(_FeaturizationBase):
     def _silence_warnings(self):
         import logging
 
-        from transformers import logging as hf_logging
+        hf_logging = _import_transformers().logging
 
         # Create a custom filter class to suppress specific warnings from huggingfaces transformers
         class SpecificMessageFilter(logging.Filter):

--- a/src/scportrait/pipeline/project.py
+++ b/src/scportrait/pipeline/project.py
@@ -28,6 +28,7 @@ from alphabase.io import tempmmap
 from spatialdata import SpatialData
 from tifffile import imread
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
 from scportrait.io import daskmmap
 from scportrait.pipeline._base import Logable
 from scportrait.pipeline._utils.helper import _check_for_spatialdata_plot, read_config, write_config
@@ -604,12 +605,13 @@ class Project(Logable):
             This only works in sessions with a visual interface.
         """
         # open interactive viewer in napari
-        try:
-            from napari_spatialdata import Interactive
-        except ImportError:
-            raise ImportError(
-                "napari-spatialdata must be installed to use the interactive viewer. Please install with `pip install scportrait[plotting]`."
-            ) from None
+        Interactive = import_optional_dependency(
+            "napari_spatialdata",
+            attribute="Interactive",
+            package_name="napari-spatialdata",
+            feature="the interactive viewer",
+            install_hint="pip install 'scportrait[plotting]'",
+        )
         self.interactive_sdata = self.filehandler.get_sdata()
         self.interactive = Interactive(self.interactive_sdata)
         self.interactive.run()

--- a/src/scportrait/pipeline/segmentation/workflows/_cellpose.py
+++ b/src/scportrait/pipeline/segmentation/workflows/_cellpose.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import numpy as np
 import torch
 from cellpose import models
-from skfmm import travel_time as skfmm_travel_time
 from skimage.morphology import dilation, disk
 from skimage.segmentation import watershed
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
 from scportrait.pipeline._utils.segmentation import (
     numba_mask_centroid,
     remove_edge_labels,
@@ -321,6 +321,14 @@ class NuclearExpansionSegmentationCellpose(DAPISegmentationCellpose):
         -------
         expanded nucleus mask
         """
+        skfmm_travel_time = import_optional_dependency(
+            "skfmm",
+            attribute="travel_time",
+            package_name="scikit-fmm",
+            feature="the fast-marching segmentation utilities and workflows",
+            install_hint="pip install 'scportrait[segmentation]'",
+        )
+
         # get centers of segmented nuclei
         nucleus_centers, _, _ids = numba_mask_centroid(nucleus_mask)
         px_centers = np.round(nucleus_centers).astype(np.uint64)

--- a/src/scportrait/pipeline/segmentation/workflows/_wga_segmentation.py
+++ b/src/scportrait/pipeline/segmentation/workflows/_wga_segmentation.py
@@ -3,11 +3,11 @@ import timeit
 
 import matplotlib.pyplot as plt
 import numpy as np
-from skfmm import travel_time as skfmm_travel_time
 from skimage.color import label2rgb
 from skimage.morphology import binary_erosion, dilation, disk
 from skimage.segmentation import watershed
 
+from scportrait._utils.optional_dependencies import import_optional_dependency
 from scportrait.pipeline._utils.segmentation import (
     contact_filter,
     global_otsu,
@@ -267,6 +267,14 @@ class _ClassicalSegmentation(_BaseSegmentation):
                 self.log(f"Filtered out {n_classes - n_classes_post} nuclei due to contact filtering.")
 
     def _cytosol_segmentation(self, input_image, debug: bool = False):
+        skfmm_travel_time = import_optional_dependency(
+            "skfmm",
+            attribute="travel_time",
+            package_name="scikit-fmm",
+            feature="the fast-marching segmentation utilities and workflows",
+            install_hint="pip install 'scportrait[segmentation]'",
+        )
+
         if not self.segment_nuclei:
             raise ValueError("Nucleus segmentation must be performed to be able to perform a cytosol segmentation.")
 

--- a/src/scportrait/plotting/_utils.py
+++ b/src/scportrait/plotting/_utils.py
@@ -1,12 +1,15 @@
 from matplotlib.axes import Axes
 from matplotlib.colors import BoundaryNorm, ListedColormap
 
-try:
-    from matplotlib_scalebar.scalebar import ScaleBar
-except ImportError:
-    raise ImportError(
-        "matplotlib_scalebar must be installed to use the plotting capabilities. please install with `pip install 'scportrait[plotting]'`."
-    ) from None
+from scportrait._utils.optional_dependencies import import_optional_dependency
+
+ScaleBar = import_optional_dependency(
+    "matplotlib_scalebar.scalebar",
+    attribute="ScaleBar",
+    package_name="matplotlib_scalebar",
+    feature="the plotting capabilities",
+    install_hint="pip install 'scportrait[plotting]'",
+)
 
 
 def _custom_cmap():

--- a/src/scportrait/plotting/_utils.py
+++ b/src/scportrait/plotting/_utils.py
@@ -3,13 +3,16 @@ from matplotlib.colors import BoundaryNorm, ListedColormap
 
 from scportrait._utils.optional_dependencies import import_optional_dependency
 
-ScaleBar = import_optional_dependency(
-    "matplotlib_scalebar.scalebar",
-    attribute="ScaleBar",
-    package_name="matplotlib_scalebar",
-    feature="the plotting capabilities",
-    install_hint="pip install 'scportrait[plotting]'",
-)
+
+def _get_scalebar_class():
+    """Return the optional ``ScaleBar`` class when plotting extras are installed."""
+    return import_optional_dependency(
+        "matplotlib_scalebar.scalebar",
+        attribute="ScaleBar",
+        package_name="matplotlib_scalebar",
+        feature="the plotting capabilities",
+        install_hint="pip install 'scportrait[plotting]'",
+    )
 
 
 def _custom_cmap():
@@ -54,6 +57,8 @@ def add_scalebar(
         scale_location: where the text labelling the scale par should be located relative to the bar. If set to "none" then there will be no label.
         border_pad: distance between scalebar element and border of the image.
     """
+    ScaleBar = _get_scalebar_class()
+
     scalebar = ScaleBar(
         resolution,
         resolution_unit,

--- a/src/scportrait/processing/images/_zstack_compression.py
+++ b/src/scportrait/processing/images/_zstack_compression.py
@@ -1,5 +1,6 @@
 import numpy as np
-from mahotas import sobel
+
+from scportrait._utils.optional_dependencies import import_optional_dependency
 
 
 def EDF(image: np.ndarray) -> np.ndarray:
@@ -12,6 +13,13 @@ def EDF(image: np.ndarray) -> np.ndarray:
     Returns:
         np.array: EDF selected image
     """
+    sobel = import_optional_dependency(
+        "mahotas",
+        attribute="sobel",
+        package_name="mahotas",
+        feature="extended depth-of-field z-stack compression",
+        install_hint="pip install 'scportrait[zstack]'",
+    )
 
     # get image stack sizes
     stack, h, w = image.shape

--- a/tests/unit_tests/pipeline/test_utils_helper.py
+++ b/tests/unit_tests/pipeline/test_utils_helper.py
@@ -2,14 +2,12 @@
 # Unit tests for ../pipeline/_utils/helper.py
 #######################################################
 
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from scportrait.pipeline._utils.helper import (
-    _check_for_spatialdata_plot,
     flatten,
     read_config,
     write_config,
@@ -55,10 +53,3 @@ def test_write_quotes_strings():
 )
 def test_flatten_list(input_list, expected_output):
     assert flatten(input_list) == expected_output
-
-
-def test_check_for_spatialdata_plot_missing(monkeypatch):
-    monkeypatch.setitem(sys.modules, "spatialdata_plot", None)
-    with pytest.raises(ImportError, match="Extended plotting capabilities"):
-        monkeypatch.delenv("spatialdata_plot", raising=False)
-        _check_for_spatialdata_plot()

--- a/tests/unit_tests/test_optional_dependencies.py
+++ b/tests/unit_tests/test_optional_dependencies.py
@@ -27,6 +27,50 @@ def test_import_optional_dependency_missing_raises_guided_error():
         )
 
 
+def test_import_optional_dependency_reraises_transitive_module_not_found(monkeypatch):
+    original = ModuleNotFoundError("No module named 'transitive_dependency'")
+    original.name = "transitive_dependency"
+
+    def _raise_transitive_failure(_module_name):
+        raise original
+
+    monkeypatch.setattr(importlib, "import_module", _raise_transitive_failure)
+
+    with pytest.raises(ModuleNotFoundError, match="transitive_dependency") as exc_info:
+        import_optional_dependency("optional_package")
+
+    assert exc_info.value is original
+
+
+def test_import_optional_dependency_non_raising_still_reraises_transitive_module_not_found(monkeypatch):
+    original = ModuleNotFoundError("No module named 'transitive_dependency'")
+    original.name = "transitive_dependency"
+
+    def _raise_transitive_failure(_module_name):
+        raise original
+
+    monkeypatch.setattr(importlib, "import_module", _raise_transitive_failure)
+
+    with pytest.raises(ModuleNotFoundError, match="transitive_dependency") as exc_info:
+        import_optional_dependency("optional_package", raise_on_missing=False)
+
+    assert exc_info.value is original
+
+
+def test_import_optional_dependency_reraises_plain_import_error(monkeypatch):
+    original = ImportError("cannot import name 'foo' from 'bar'")
+
+    def _raise_import_error(_module_name):
+        raise original
+
+    monkeypatch.setattr(importlib, "import_module", _raise_import_error)
+
+    with pytest.raises(ImportError, match="cannot import name") as exc_info:
+        import_optional_dependency("optional_package")
+
+    assert exc_info.value is original
+
+
 def test_deprecation_helper_exports_decorator():
     from scportrait._utils.deprecation import deprecated
 
@@ -42,13 +86,31 @@ def test_check_for_spatialdata_plot_missing(monkeypatch):
         _check_for_spatialdata_plot()
 
 
-def test_plotting_utils_missing_matplotlib_scalebar_raises_guided_error(monkeypatch):
+def test_plotting_utils_import_without_matplotlib_scalebar_keeps_custom_cmap_available(monkeypatch):
     monkeypatch.setitem(sys.modules, "matplotlib_scalebar", None)
     monkeypatch.setitem(sys.modules, "matplotlib_scalebar.scalebar", None)
     sys.modules.pop("scportrait.plotting._utils", None)
 
+    plotting_utils = importlib.import_module("scportrait.plotting._utils")
+
+    cmap, norm = plotting_utils._custom_cmap()
+
+    assert cmap.N == 3
+    assert norm is not None
+
+
+def test_add_scalebar_missing_matplotlib_scalebar_raises_guided_error(monkeypatch):
+    from scportrait.plotting._utils import add_scalebar
+
+    monkeypatch.setitem(sys.modules, "matplotlib_scalebar", None)
+    monkeypatch.setitem(sys.modules, "matplotlib_scalebar.scalebar", None)
+
+    class _DummyAxes:
+        def add_artist(self, _artist):
+            raise AssertionError("add_artist should not be called when matplotlib_scalebar is missing")
+
     with pytest.raises(ImportError, match=r"scportrait\[plotting\]"):
-        importlib.import_module("scportrait.plotting._utils")
+        add_scalebar(_DummyAxes(), resolution=1.0)
 
 
 def test_project_view_sdata_missing_napari_spatialdata_raises_guided_error(monkeypatch):

--- a/tests/unit_tests/test_optional_dependencies.py
+++ b/tests/unit_tests/test_optional_dependencies.py
@@ -1,0 +1,130 @@
+import importlib
+import sys
+
+import numpy as np
+import pytest
+from skimage import data
+
+from scportrait._utils.optional_dependencies import import_optional_dependency
+
+
+def test_import_optional_dependency_returns_attribute():
+    sqrt = import_optional_dependency("math", attribute="sqrt")
+    assert sqrt(16) == 4
+
+
+def test_import_optional_dependency_returns_none_when_non_raising():
+    assert import_optional_dependency("scportrait_missing_test_dependency", raise_on_missing=False) is None
+
+
+def test_import_optional_dependency_missing_raises_guided_error():
+    with pytest.raises(ImportError, match=r"scportrait\[plotting\]"):
+        import_optional_dependency(
+            "scportrait_missing_test_dependency",
+            package_name="fake-package",
+            feature="the plotting capabilities",
+            install_hint="pip install 'scportrait[plotting]'",
+        )
+
+
+def test_deprecation_helper_exports_decorator():
+    from scportrait._utils.deprecation import deprecated
+
+    assert callable(deprecated)
+
+
+def test_check_for_spatialdata_plot_missing(monkeypatch):
+    from scportrait.pipeline._utils.helper import _check_for_spatialdata_plot
+
+    monkeypatch.setitem(sys.modules, "spatialdata_plot", None)
+
+    with pytest.raises(ImportError, match="Extended plotting capabilities"):
+        _check_for_spatialdata_plot()
+
+
+def test_plotting_utils_missing_matplotlib_scalebar_raises_guided_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "matplotlib_scalebar", None)
+    monkeypatch.setitem(sys.modules, "matplotlib_scalebar.scalebar", None)
+    sys.modules.pop("scportrait.plotting._utils", None)
+
+    with pytest.raises(ImportError, match=r"scportrait\[plotting\]"):
+        importlib.import_module("scportrait.plotting._utils")
+
+
+def test_project_view_sdata_missing_napari_spatialdata_raises_guided_error(monkeypatch):
+    from scportrait.pipeline.project import Project
+
+    monkeypatch.setitem(sys.modules, "napari_spatialdata", None)
+
+    project = Project.__new__(Project)
+    project.log = lambda *_args, **_kwargs: None
+
+    with pytest.raises(ImportError, match=r"scportrait\[plotting\]"):
+        Project.view_sdata(project)
+
+
+def test_import_transformers_missing_raises_guided_error(monkeypatch):
+    from scportrait.pipeline.featurization import _import_transformers
+
+    monkeypatch.setitem(sys.modules, "transformers", None)
+
+    with pytest.raises(ImportError, match=r"scportrait\[convnext\]"):
+        _import_transformers()
+
+
+def test_zstack_compression_module_import_without_mahotas(monkeypatch):
+    import scportrait.processing.images._zstack_compression as zstack_compression
+
+    monkeypatch.setitem(sys.modules, "mahotas", None)
+
+    reloaded = importlib.reload(zstack_compression)
+
+    assert hasattr(reloaded, "EDF")
+
+
+def test_edf_missing_mahotas_raises_guided_error(monkeypatch):
+    from scportrait.processing.images._zstack_compression import EDF
+
+    monkeypatch.setitem(sys.modules, "mahotas", None)
+
+    with pytest.raises(ImportError, match=r"scportrait\[zstack\]"):
+        EDF(np.zeros((2, 4, 4), dtype=np.uint16))
+
+
+def test_segmentation_utils_module_import_without_skfmm(monkeypatch):
+    import scportrait.pipeline._utils.segmentation as segmentation_utils
+
+    monkeypatch.setitem(sys.modules, "skfmm", None)
+
+    reloaded = importlib.reload(segmentation_utils)
+
+    assert hasattr(reloaded, "segment_global_threshold")
+
+
+def test_cellpose_workflow_module_import_without_skfmm(monkeypatch):
+    import scportrait.pipeline.segmentation.workflows._cellpose as cellpose_workflow
+
+    monkeypatch.setitem(sys.modules, "skfmm", None)
+
+    reloaded = importlib.reload(cellpose_workflow)
+
+    assert hasattr(reloaded, "NuclearExpansionSegmentationCellpose")
+
+
+def test_wga_workflow_module_import_without_skfmm(monkeypatch):
+    import scportrait.pipeline.segmentation.workflows._wga_segmentation as wga_segmentation
+
+    monkeypatch.setitem(sys.modules, "skfmm", None)
+
+    reloaded = importlib.reload(wga_segmentation)
+
+    assert hasattr(reloaded, "WGASegmentation")
+
+
+def test_segment_global_threshold_missing_skfmm_raises_guided_error(monkeypatch):
+    from scportrait.pipeline._utils.segmentation import segment_global_threshold
+
+    monkeypatch.setitem(sys.modules, "skfmm", None)
+
+    with pytest.raises(ImportError, match=r"scportrait\[segmentation\]"):
+        segment_global_threshold(data.coins())


### PR DESCRIPTION
- add support for  3.13/3.14 (#395)
- drop support for python 3.10 (#368)
- clean up optional dependencies to utilise same wrapper
- makes scikit-fmm and mahotas optional dependencies
- add python version unit test matrix runner
- add OS unit test matrix runner