### PR TITLE
[FIX] failing tests

### DIFF
--- a/src/scportrait/plotting/sdata.py
+++ b/src/scportrait/plotting/sdata.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from collections.abc import Iterable
 from math import ceil
@@ -35,6 +36,13 @@ PALETTE = [
 ]
 
 from scportrait.pipeline._utils.helper import _check_for_spatialdata_plot
+
+
+def _call_plot_renderer(renderer, *args, method: str | None = None, **kwargs):
+    """Call a spatialdata_plot renderer, passing ``method`` only when supported."""
+    if method is not None and "method" in inspect.signature(renderer).parameters:
+        kwargs["method"] = method
+    return renderer(*args, **kwargs)
 
 
 def _is_valid_matplotlib_color(color: str | None) -> bool:
@@ -88,7 +96,8 @@ def _render_labels_as_fixed_color_shapes(
     vectorized_layer = f"{label_layer}_vectorized"
     if vectorized_layer not in sdata:
         sdata[vectorized_layer] = spatialdata.to_polygons(sdata[label_layer])
-    sdata.pl.render_shapes(
+    _call_plot_renderer(
+        sdata.pl.render_shapes,
         vectorized_layer,
         color=color,
         fill_alpha=fill_alpha,
@@ -494,7 +503,8 @@ def plot_shapes(
         prev_annotation = sdata["_annotation"] if had_annotation else None
         sdata["_annotation"] = annotating_table
         try:
-            sdata.pl.render_shapes(
+            _call_plot_renderer(
+                sdata.pl.render_shapes,
                 f"{shapes_layer}",
                 fill_alpha=fill_alpha,
                 color=fill_color,
@@ -512,7 +522,8 @@ def plot_shapes(
             else:
                 del sdata["_annotation"]
     else:
-        sdata.pl.render_shapes(
+        _call_plot_renderer(
+            sdata.pl.render_shapes,
             f"{shapes_layer}",
             fill_alpha=fill_alpha,
             color=fill_color,
@@ -663,7 +674,8 @@ def plot_labels(
                 prev_annotation = sdata["_annotation"] if had_annotation else None
                 sdata["_annotation"] = annotating_table
                 try:
-                    sdata.pl.render_shapes(
+                    _call_plot_renderer(
+                        sdata.pl.render_shapes,
                         f"{label_layer}_vectorized",
                         color=color,
                         fill_alpha=fill_alpha,
@@ -681,7 +693,8 @@ def plot_labels(
                         del sdata["_annotation"]  # delete element again after plotting
             else:
                 try:
-                    sdata.pl.render_labels(
+                    _call_plot_renderer(
+                        sdata.pl.render_labels,
                         f"{label_layer}",
                         color=color,
                         fill_alpha=fill_alpha,
@@ -707,7 +720,8 @@ def plot_labels(
             )
         else:
             try:
-                sdata.pl.render_labels(
+                _call_plot_renderer(
+                    sdata.pl.render_labels,
                     f"{label_layer}",
                     color=color,
                     fill_alpha=fill_alpha,

--- a/tests/unit_tests/plotting/test_sdata.py
+++ b/tests/unit_tests/plotting/test_sdata.py
@@ -152,6 +152,36 @@ def test_plot_labels_with_ax_returns_fig(sdata_with_labels):
     plt.close(fig)
 
 
+def test_call_plot_renderer_omits_unsupported_method():
+    recorded = {}
+
+    def renderer(*args, **kwargs):
+        recorded["args"] = args
+        recorded["kwargs"] = kwargs
+        return kwargs
+
+    plotting._call_plot_renderer(renderer, "layer", color="red", method="matplotlib")
+
+    assert recorded["args"] == ("layer",)
+    assert recorded["kwargs"] == {"color": "red"}
+
+
+def test_call_plot_renderer_passes_supported_method():
+    recorded = {}
+
+    def renderer(*args, method=None, **kwargs):
+        recorded["args"] = args
+        recorded["kwargs"] = kwargs
+        recorded["method"] = method
+        return kwargs
+
+    plotting._call_plot_renderer(renderer, "layer", color="red", method="matplotlib")
+
+    assert recorded["args"] == ("layer",)
+    assert recorded["kwargs"] == {"color": "red"}
+    assert recorded["method"] == "matplotlib"
+
+
 def test_plot_labels_groups_normalized(sdata_with_labels):
     first_group = sdata_with_labels["table"].obs["labelling_categorical"].iloc[0]
     fig = plotting.plot_labels(


### PR DESCRIPTION
spatialdata-plot changed render_labels() so it no longer accepts the method kwarg as of the 0.3.0 API line. scPortrait.plotting.plot_labels() was still forwarding method unconditionally, which breaks on newer versions with TypeError: PlotAccessor.render_labels() got an unexpected keyword argument 'method'.

This PR makes renderer calls compatibility-safe by only passing method when the target spatialdata_plot renderer actually supports it. That preserves backend selection for shapes and older-compatible paths, while allowing label rendering to use the current upstream API.

**Impact:**

fixes CI failures in test_plot_labels
keeps compatibility across older and newer spatialdata-plot versions
preserves method behavior where upstream still documents it, especially render_shapes() and render_points()
Verification:

added regression tests covering both cases: omit method when unsupported, pass it when supported
local static verification passed with python -m compileall
full pytest run was not possible in the local shell because pytest is not installed in this environment